### PR TITLE
Define Location id as String instead if int.

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractEfaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractEfaProvider.java
@@ -930,7 +930,7 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider
 		return nearbyStationsRequest(location.id, maxStations);
 	}
 
-	private NearbyStationsResult nearbyStationsRequest(final int stationId, final int maxStations) throws IOException
+	private NearbyStationsResult nearbyStationsRequest(final String stationId, final int maxStations) throws IOException
 	{
 		final StringBuilder parameters = new StringBuilder();
 		appendCommonRequestParams(parameters, "XML");
@@ -1442,7 +1442,7 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider
 				+ "' trainType='" + trainType + "' trainNum='" + trainNum + "' trainName='" + trainName + "'");
 	}
 
-	protected StringBuilder queryDeparturesParameters(final int stationId, final int maxDepartures, final boolean equivs)
+	protected StringBuilder queryDeparturesParameters(final String stationId, final int maxDepartures, final boolean equivs)
 	{
 		final StringBuilder parameters = new StringBuilder();
 		appendCommonRequestParams(parameters, "XML");
@@ -1460,7 +1460,7 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider
 		return parameters;
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder parameters = queryDeparturesParameters(stationId, maxDepartures, equivs);
 
@@ -1506,7 +1506,7 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider
 					while (XmlPullUtil.test(pp, "itdOdvAssignedStop"))
 					{
 						final Location assignedLocation = processItdOdvAssignedStop(pp);
-						if (findStationDepartures(result.stationDepartures, assignedLocation.id) == null)
+						if (findStationDepartures(result.stationDepartures, Integer.parseInt(assignedLocation.id)) == null)
 							result.stationDepartures.add(new StationDepartures(assignedLocation, new LinkedList<Departure>(),
 									new LinkedList<LineDestination>()));
 					}
@@ -1671,7 +1671,7 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider
 		}
 	}
 
-	protected QueryDeparturesResult queryDeparturesMobile(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	protected QueryDeparturesResult queryDeparturesMobile(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder parameters = queryDeparturesParameters(stationId, maxDepartures, equivs);
 
@@ -1860,7 +1860,7 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider
 	private StationDepartures findStationDepartures(final List<StationDepartures> stationDepartures, final int id)
 	{
 		for (final StationDepartures stationDeparture : stationDepartures)
-			if (stationDeparture.location.id == id)
+			if ((Integer.parseInt(stationDeparture.location.id)) == id)
 				return stationDeparture;
 
 		return null;
@@ -2693,11 +2693,11 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider
 							final int size = intermediateStops.size();
 							if (size >= 2)
 							{
-								if (intermediateStops.get(size - 1).location.id != arrivalLocation.id)
+								if (!(intermediateStops.get(size - 1).location.id.equals(arrivalLocation.id)))
 									throw new IllegalStateException();
 								intermediateStops.remove(size - 1);
 
-								if (intermediateStops.get(0).location.id != departureLocation.id)
+								if (!(intermediateStops.get(0).location.id.equals(departureLocation.id)))
 									throw new IllegalStateException();
 								intermediateStops.remove(0);
 							}
@@ -2961,7 +2961,7 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider
 								final String s = requireValueTag(pp, "s");
 								final String[] intermediateParts = s.split(";");
 								final int id = Integer.parseInt(intermediateParts[0]);
-								if (id != departure.location.id && id != arrival.location.id)
+								if (id != Integer.parseInt(departure.location.id) && id != Integer.parseInt(arrival.location.id))
 								{
 									final String name = normalizeLocationName(intermediateParts[1]);
 
@@ -3300,7 +3300,7 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider
 	protected static final String locationValue(final Location location)
 	{
 		if ((location.type == LocationType.STATION || location.type == LocationType.POI) && location.hasId())
-			return Integer.toString(location.id);
+			return location.id;
 		else
 			return location.name;
 	}

--- a/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
@@ -569,7 +569,7 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider
 		}
 	}
 
-	protected StringBuilder xmlQueryDeparturesParameters(final int stationId)
+	protected StringBuilder xmlQueryDeparturesParameters(final String stationId)
 	{
 		final StringBuilder parameters = new StringBuilder();
 		parameters.append("?productsFilter=").append(allProductsString());
@@ -588,7 +588,7 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider
 
 	private static final Pattern P_XML_QUERY_DEPARTURES_DELAY = Pattern.compile("(?:-|k\\.A\\.?|cancel|\\+?\\s*(\\d+))");
 
-	protected QueryDeparturesResult xmlQueryDepartures(final String uri, final int stationId) throws IOException
+	protected QueryDeparturesResult xmlQueryDepartures(final String uri, final String stationId) throws IOException
 	{
 		StringReplaceReader reader = null;
 
@@ -1492,7 +1492,7 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider
 		throw new IllegalArgumentException(location.type.toString());
 	}
 
-	protected boolean isValidStationId(int id)
+	protected boolean isValidStationId(String id)
 	{
 		return true;
 	}
@@ -2237,7 +2237,7 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider
 		return new Position(m.group(1));
 	}
 
-	protected final StringBuilder xmlNearbyStationsParameters(final int stationId)
+	protected final StringBuilder xmlNearbyStationsParameters(final String stationId)
 	{
 		final StringBuilder parameters = new StringBuilder();
 		parameters.append("?productsFilter=").append(allProductsString());

--- a/enabler/src/de/schildbach/pte/AbstractNetworkProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNetworkProvider.java
@@ -18,6 +18,7 @@
 package de.schildbach.pte;
 
 import java.nio.charset.Charset;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -25,6 +26,7 @@ import java.util.Set;
 
 import de.schildbach.pte.dto.Point;
 import de.schildbach.pte.dto.Product;
+import de.schildbach.pte.dto.QueryDeparturesResult;
 import de.schildbach.pte.dto.Style;
 
 /**
@@ -44,6 +46,14 @@ public abstract class AbstractNetworkProvider implements NetworkProvider
 	{
 		ALL_EXCEPT_HIGHSPEED = new HashSet<Product>(Product.ALL);
 		ALL_EXCEPT_HIGHSPEED.remove(Product.HIGH_SPEED_TRAIN);
+	}
+
+	public QueryDeparturesResult queryDepartures(int stationId, int maxDepartures, boolean equivs) throws IOException
+	{
+		if (stationId == 0)
+			return queryDepartures(null, maxDepartures, equivs);
+		else
+			return queryDepartures(Integer.toString(stationId), maxDepartures, equivs);
 	}
 
 	public Collection<Product> defaultProducts()

--- a/enabler/src/de/schildbach/pte/BahnProvider.java
+++ b/enabler/src/de/schildbach/pte/BahnProvider.java
@@ -156,7 +156,7 @@ public final class BahnProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/BayernProvider.java
+++ b/enabler/src/de/schildbach/pte/BayernProvider.java
@@ -117,7 +117,7 @@ public class BayernProvider extends AbstractEfaProvider
 	}
 
 	@Override
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		return queryDeparturesMobile(stationId, maxDepartures, equivs);
 	}

--- a/enabler/src/de/schildbach/pte/BvgProvider.java
+++ b/enabler/src/de/schildbach/pte/BvgProvider.java
@@ -258,7 +258,7 @@ public final class BvgProvider extends AbstractHafasProvider
 
 	private static final String DEPARTURE_URL_LIVE = DEPARTURE_URL + "/IstAbfahrtzeiten/index/mobil?";
 
-	private String departuresQueryLiveUri(final int stationId)
+	private String departuresQueryLiveUri(final String stationId)
 	{
 		final StringBuilder uri = new StringBuilder();
 		uri.append(DEPARTURE_URL_LIVE);
@@ -270,7 +270,7 @@ public final class BvgProvider extends AbstractHafasProvider
 
 	private static final String DEPARTURE_URL_PLAN = DEPARTURE_URL + "/Fahrinfo/bin/stboard.bin/dox?boardType=dep&disableEquivs=yes&start=yes";
 
-	private String departuresQueryPlanUri(final int stationId, final int maxDepartures)
+	private String departuresQueryPlanUri(final String stationId, final int maxDepartures)
 	{
 		final StringBuilder uri = new StringBuilder();
 		uri.append(DEPARTURE_URL_PLAN);
@@ -320,12 +320,12 @@ public final class BvgProvider extends AbstractHafasProvider
 	private static final Pattern P_DEPARTURES_LIVE_ERRORS = Pattern.compile(
 			"(Haltestelle:)|(Wartungsgr&uuml;nden|nur eingeschränkt)|(http-equiv=\"refresh\")", Pattern.CASE_INSENSITIVE);
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final ResultHeader header = new ResultHeader(SERVER_PRODUCT);
 		final QueryDeparturesResult result = new QueryDeparturesResult(header);
 
-		if (stationId < 1000000) // live
+		if (Integer.parseInt(stationId) < 1000000) // live
 		{
 			// scrape page
 			final String uri = departuresQueryLiveUri(stationId);
@@ -521,9 +521,9 @@ public final class BvgProvider extends AbstractHafasProvider
 	}
 
 	@Override
-	protected boolean isValidStationId(int id)
+	protected boolean isValidStationId(String id)
 	{
-		return id >= 1000000;
+		return Integer.parseInt(id) >= 1000000;
 	}
 
 	@Override

--- a/enabler/src/de/schildbach/pte/DsbProvider.java
+++ b/enabler/src/de/schildbach/pte/DsbProvider.java
@@ -135,7 +135,7 @@ public class DsbProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/EireannProvider.java
+++ b/enabler/src/de/schildbach/pte/EireannProvider.java
@@ -117,7 +117,7 @@ public class EireannProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/InvgProvider.java
+++ b/enabler/src/de/schildbach/pte/InvgProvider.java
@@ -113,7 +113,7 @@ public class InvgProvider extends AbstractHafasProvider
 		}
 	}
 
-	private String departuresQueryUri(final int stationId, final int maxDepartures)
+	private String departuresQueryUri(final String stationId, final int maxDepartures)
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append("?input=").append(stationId);
@@ -157,7 +157,7 @@ public class InvgProvider extends AbstractHafasProvider
 			+ "(?:<td class=\"center sepline top\">\n(" + ParserUtils.P_PLATFORM + ").*?)?" // position
 	, Pattern.DOTALL);
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final ResultHeader header = new ResultHeader(SERVER_PRODUCT);
 		final QueryDeparturesResult result = new QueryDeparturesResult(header);

--- a/enabler/src/de/schildbach/pte/JetProvider.java
+++ b/enabler/src/de/schildbach/pte/JetProvider.java
@@ -136,7 +136,7 @@ public class JetProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/LuProvider.java
+++ b/enabler/src/de/schildbach/pte/LuProvider.java
@@ -137,7 +137,7 @@ public class LuProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/NasaProvider.java
+++ b/enabler/src/de/schildbach/pte/NasaProvider.java
@@ -158,7 +158,7 @@ public class NasaProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/NetworkProvider.java
+++ b/enabler/src/de/schildbach/pte/NetworkProvider.java
@@ -96,7 +96,21 @@ public interface NetworkProvider
 	 * @return result object containing the departures
 	 * @throws IOException
 	 */
-	QueryDeparturesResult queryDepartures(int stationId, int maxDepartures, boolean equivs) throws IOException;
+	QueryDeparturesResult queryDepartures(String stationId, int maxDepartures, boolean equivs) throws IOException;
+
+	/**
+	 * Get departures at a given station, probably live
+	 * 
+	 * @param stationId
+	 *            id of the station
+	 * @param maxDepartures
+	 *            maximum number of departures to get or {@code 0}
+	 * @param equivs
+	 *            also query equivalent stations?
+	 * @return result object containing the departures
+	 * @throws IOException
+	 */
+	 QueryDeparturesResult queryDepartures(int stationId, int maxDepartures, boolean equivs) throws IOException;
 
 	/**
 	 * Meant for auto-completion of station names, like in an {@link android.widget.AutoCompleteTextView}

--- a/enabler/src/de/schildbach/pte/NriProvider.java
+++ b/enabler/src/de/schildbach/pte/NriProvider.java
@@ -153,7 +153,7 @@ public class NriProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/NsProvider.java
+++ b/enabler/src/de/schildbach/pte/NsProvider.java
@@ -128,7 +128,7 @@ public class NsProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		throw new UnsupportedOperationException();
 	}

--- a/enabler/src/de/schildbach/pte/NvvProvider.java
+++ b/enabler/src/de/schildbach/pte/NvvProvider.java
@@ -179,7 +179,7 @@ public class NvvProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/OebbProvider.java
+++ b/enabler/src/de/schildbach/pte/OebbProvider.java
@@ -168,7 +168,7 @@ public class OebbProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/PlProvider.java
+++ b/enabler/src/de/schildbach/pte/PlProvider.java
@@ -154,7 +154,7 @@ public class PlProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/RtProvider.java
+++ b/enabler/src/de/schildbach/pte/RtProvider.java
@@ -122,7 +122,7 @@ public class RtProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/SadProvider.java
+++ b/enabler/src/de/schildbach/pte/SadProvider.java
@@ -97,7 +97,7 @@ public class SadProvider extends AbstractNetworkProvider {
 		throw new UnsupportedOperationException();
 	}
 
-	public QueryDeparturesResult queryDepartures(int stationId, int maxDepartures, boolean equivs) throws IOException {
+	public QueryDeparturesResult queryDepartures(String stationId, int maxDepartures, boolean equivs) throws IOException {
 		// Not supported by SOAP API
 		throw new UnsupportedOperationException();
 	}

--- a/enabler/src/de/schildbach/pte/SbbProvider.java
+++ b/enabler/src/de/schildbach/pte/SbbProvider.java
@@ -119,7 +119,7 @@ public class SbbProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/SeProvider.java
+++ b/enabler/src/de/schildbach/pte/SeProvider.java
@@ -176,7 +176,7 @@ public class SeProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/SeptaProvider.java
+++ b/enabler/src/de/schildbach/pte/SeptaProvider.java
@@ -136,7 +136,7 @@ public class SeptaProvider extends AbstractHafasProvider
 		}
 	}
 
-	private String departuresQueryUri(final int stationId, final int maxDepartures)
+	private String departuresQueryUri(final String stationId, final int maxDepartures)
 	{
 		final Calendar now = new GregorianCalendar(timeZone());
 
@@ -183,7 +183,7 @@ public class SeptaProvider extends AbstractHafasProvider
 			+ "(?:<td class=\"center sepline top\">\n(" + ParserUtils.P_PLATFORM + ").*?)?" // position
 	, Pattern.DOTALL);
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final ResultHeader header = new ResultHeader(SERVER_PRODUCT);
 		final QueryDeparturesResult result = new QueryDeparturesResult(header);

--- a/enabler/src/de/schildbach/pte/ShProvider.java
+++ b/enabler/src/de/schildbach/pte/ShProvider.java
@@ -131,7 +131,7 @@ public class ShProvider extends AbstractHafasProvider
 		}
 	}
 
-	private String departuresQueryUri(final int stationId, final int maxDepartures)
+	private String departuresQueryUri(final String stationId, final int maxDepartures)
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append("?input=").append(stationId);
@@ -166,7 +166,7 @@ public class ShProvider extends AbstractHafasProvider
 			+ "(?:<td class=\"center sepline top\">\n(" + ParserUtils.P_PLATFORM + ").*?)?" // position
 	, Pattern.DOTALL);
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final ResultHeader header = new ResultHeader(SERVER_PRODUCT);
 		final QueryDeparturesResult result = new QueryDeparturesResult(header);

--- a/enabler/src/de/schildbach/pte/SncbProvider.java
+++ b/enabler/src/de/schildbach/pte/SncbProvider.java
@@ -148,7 +148,7 @@ public class SncbProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/StockholmProvider.java
+++ b/enabler/src/de/schildbach/pte/StockholmProvider.java
@@ -165,7 +165,7 @@ public class StockholmProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/VbbProvider.java
+++ b/enabler/src/de/schildbach/pte/VbbProvider.java
@@ -173,7 +173,7 @@ public class VbbProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/VbnProvider.java
+++ b/enabler/src/de/schildbach/pte/VbnProvider.java
@@ -141,7 +141,7 @@ public class VbnProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/VgsProvider.java
+++ b/enabler/src/de/schildbach/pte/VgsProvider.java
@@ -144,7 +144,7 @@ public class VgsProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/ZvvProvider.java
+++ b/enabler/src/de/schildbach/pte/ZvvProvider.java
@@ -184,7 +184,7 @@ public class ZvvProvider extends AbstractHafasProvider
 		}
 	}
 
-	public QueryDeparturesResult queryDepartures(final int stationId, final int maxDepartures, final boolean equivs) throws IOException
+	public QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures, final boolean equivs) throws IOException
 	{
 		final StringBuilder uri = new StringBuilder(stationBoardEndpoint);
 		uri.append(xmlQueryDeparturesParameters(stationId));

--- a/enabler/src/de/schildbach/pte/dto/Location.java
+++ b/enabler/src/de/schildbach/pte/dto/Location.java
@@ -28,12 +28,12 @@ public final class Location implements Serializable
 	private static final long serialVersionUID = 2168486169241327168L;
 
 	public final LocationType type;
-	public final int id;
+	public final String id;
 	public final int lat, lon;
 	public final String place;
 	public final String name;
 
-	public Location(final LocationType type, final int id, final int lat, final int lon, final String place, final String name)
+	public Location(final LocationType type, final String id, final int lat, final int lon, final String place, final String name)
 	{
 		assertId(id);
 
@@ -45,7 +45,22 @@ public final class Location implements Serializable
 		this.name = name;
 	}
 
-	public Location(final LocationType type, final int id, final String place, final String name)
+	public Location(final LocationType type, final int id, final int lat, final int lon, final String place, final String name)
+	{
+		assertIntId(id);
+
+		this.type = type;
+		if (id == 0)
+			this.id = null;
+		else
+			this.id = Integer.toString(id);
+		this.lat = lat;
+		this.lon = lon;
+		this.place = place;
+		this.name = name;
+	}
+
+	public Location(final LocationType type, final String id, final String place, final String name)
 	{
 		assertId(id);
 
@@ -57,7 +72,22 @@ public final class Location implements Serializable
 		this.name = name;
 	}
 
-	public Location(final LocationType type, final int id, final int lat, final int lon)
+	public Location(final LocationType type, final int id, final String place, final String name)
+	{
+		assertIntId(id);
+
+		this.type = type;
+		if (id == 0)
+			this.id = null;
+		else
+			this.id = Integer.toString(id);
+		this.lat = 0;
+		this.lon = 0;
+		this.place = place;
+		this.name = name;
+	}
+
+	public Location(final LocationType type, final String id, final int lat, final int lon)
 	{
 		assertId(id);
 
@@ -69,12 +99,42 @@ public final class Location implements Serializable
 		this.name = null;
 	}
 
-	public Location(final LocationType type, final int id)
+	public Location(final LocationType type, final int id, final int lat, final int lon)
+	{
+		assertIntId(id);
+
+		this.type = type;
+		if (id == 0)
+			this.id = null;
+		else
+			this.id = Integer.toString(id);
+		this.lat = lat;
+		this.lon = lon;
+		this.place = null;
+		this.name = null;
+	}
+
+	public Location(final LocationType type, final String id)
 	{
 		assertId(id);
 
 		this.type = type;
 		this.id = id;
+		this.lat = 0;
+		this.lon = 0;
+		this.place = null;
+		this.name = null;
+	}
+
+	public Location(final LocationType type, final int id)
+	{
+		assertIntId(id);
+
+		this.type = type;
+		if (id == 0)
+			this.id = null;
+		else
+			this.id = Integer.toString(id);
 		this.lat = 0;
 		this.lon = 0;
 		this.place = null;
@@ -84,7 +144,7 @@ public final class Location implements Serializable
 	public Location(final LocationType type, final int lat, final int lon)
 	{
 		this.type = type;
-		this.id = 0;
+		this.id = null;
 		this.lat = lat;
 		this.lon = lon;
 		this.place = null;
@@ -93,7 +153,7 @@ public final class Location implements Serializable
 
 	public final boolean hasId()
 	{
-		return id != 0;
+		return id != null;
 	}
 
 	public final boolean hasLocation()
@@ -128,7 +188,7 @@ public final class Location implements Serializable
 		else if (name != null)
 			return name;
 		else if (hasId())
-			return Integer.toString(id);
+			return id;
 		else
 			return null;
 	}
@@ -154,8 +214,8 @@ public final class Location implements Serializable
 		final Location other = (Location) o;
 		if (this.type != other.type)
 			return false;
-		if (this.id != 0)
-			return this.id == other.id;
+		if (this.id != null)
+			return this.id.equals(other.id);
 		if (this.lat != 0 && this.lon != 0)
 			return this.lat == other.lat && this.lon == other.lon;
 		if (!nullSafeEquals(this.name, other.name)) // only discriminate by name if no ids are given
@@ -169,9 +229,9 @@ public final class Location implements Serializable
 		int hashCode = 0;
 		hashCode += type.hashCode();
 		hashCode *= 29;
-		if (id != 0)
+		if (id != null)
 		{
-			hashCode += id;
+			hashCode += id.hashCode();
 		}
 		else if (lat != 0 || lon != 0)
 		{
@@ -198,7 +258,13 @@ public final class Location implements Serializable
 		return o.hashCode();
 	}
 
-	private static void assertId(final int id)
+	private static void assertId(final String id)
+	{
+		if (id == null)
+			throw new IllegalStateException("assert failed: id=null");
+	}
+
+	private static void assertIntId(final int id)
 	{
 		if (id < 0)
 			throw new IllegalStateException("assert failed: id=" + id);


### PR DESCRIPTION
This pull request allows instanciating Location objects with an id that is not necessarly an integer.
- Location.id attribute is of type String instead of int.
- Define new Location constructors.
- Migrate providers.
- Unit tests are still functional.
