### PR TITLE
Handle String id correctly in Location assertId.

### DIFF
--- a/enabler/src/de/schildbach/pte/dto/Location.java
+++ b/enabler/src/de/schildbach/pte/dto/Location.java
@@ -198,7 +198,17 @@ public final class Location implements Serializable
 
 	private static void assertId(final String id)
 	{
-		if (id != null && Integer.parseInt(id) <= 0)
-			throw new IllegalStateException("assert failed: id=" + id);
+		if (id != null)
+		{
+			try
+			{
+				if (Integer.parseInt(id) <= 0)
+					throw new IllegalStateException("assert failed: id=" + id);
+			}
+			catch(NumberFormatException nfExc)
+			{
+				return;
+			}
+		}
 	}
 }


### PR DESCRIPTION
The current implementation of assertId in Location.java raises an assertion when a location id is a string, which is an acceptable case.

This commit fixes the issue by catching a NumberFormatException when calling Integer.ParseInt(id).

Thanks for merging if you think this is a good fix.
