### PR TITLE
Replace whitespace with "%20" before scraping url.

### DIFF
--- a/enabler/src/de/schildbach/pte/util/ParserUtils.java
+++ b/enabler/src/de/schildbach/pte/util/ParserUtils.java
@@ -115,7 +115,8 @@ public final class ParserUtils
 
 		while (true)
 		{
-			final URL url = new URL(urlStr);
+			final String urlStrCleaned = urlStr.replaceAll(" ", "%20");
+			final URL url = new URL(urlStrCleaned);
 			final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 
 			connection.setDoInput(true);


### PR DESCRIPTION
With this commit, url strings such as

```
http://api.navitia.io/v1/coverage/fr-idf/places?q=13 rue man&type[]=stop_area&type[]=address&depth=1
```

would be cut off to

```
http://api.navitia.io/v1/coverage/fr-idf/places?q=13
```
