### PR TITLE
Fix NearbyStationsResult printer in case of invalid station.

### DIFF
--- a/enabler/src/de/schildbach/pte/dto/NearbyStationsResult.java
+++ b/enabler/src/de/schildbach/pte/dto/NearbyStationsResult.java
@@ -53,7 +53,10 @@ public final class NearbyStationsResult implements Serializable
 	{
 		final StringBuilder builder = new StringBuilder(getClass().getSimpleName());
 		builder.append("[").append(this.status);
-		builder.append(" ").append(stations.size()).append(stations);
+		if (this.stations != null)
+		{
+			builder.append(" ").append(stations.size()).append(stations);
+		}
 		builder.append("]");
 		return builder.toString();
 	}


### PR DESCRIPTION
- If input station is invalid, the constructor sets the stations
  list to null.
- Check that stations list is not null before trying to append its
  content to string builder.
