### PR TITLE
Line colors for buses in Kiel (ShProvider)

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
@@ -591,6 +591,12 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider
 				final String delayReason = XmlPullUtil.optAttr(pp, "delayReason", null);
 				// TODO is_reachable
 				// TODO disableTrainInfo
+				String administration = XmlPullUtil.optAttr(pp, "administration", null);
+				Pattern pattern = Pattern.compile("([^_]*)_*");
+				Matcher matcher = pattern.matcher(administration);
+				if (matcher.find()) {
+					administration = matcher.group(1);
+				}
 
 				if (!"cancel".equals(eDelay))
 				{
@@ -668,13 +674,17 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider
 						// could check for type consistency here
 						final Set<Attr> attrs = prodLine.attrs;
 						if (attrs != null)
-							line = newLine(product, prodLine.label, null, attrs.toArray(new Line.Attr[0]));
+							line = newLine(administration, product, prodLine.label, null, attrs.toArray(new Line.Attr[0]));
 						else
-							line = newLine(product, prodLine.label, null);
+							line = newLine(administration, product, prodLine.label, null);
 					}
 					else
 					{
-						line = prodLine;
+						if (prodLine.attrs != null) {
+							line = newLine(administration, prodLine.product, prodLine.label, null, prodLine.attrs.toArray(new Line.Attr[0]));
+						} else {
+							line = newLine(administration, prodLine.product, prodLine.label, null);
+						}
 					}
 
 					final int[] capacity;
@@ -3114,18 +3124,22 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider
 		throw new IllegalStateException("cannot normalize line#type '" + lineAndType + "'");
 	}
 
-	protected Line newLine(final Product product, final String normalizedName, final String comment, final Line.Attr... attrs)
+	protected Line newLine(final Product product, final String normalizedName, final String comment, final Line.Attr... attrs) {
+		return newLine(null, product, normalizedName, comment, attrs);
+	}
+
+	protected Line newLine(final String network, final Product product, final String normalizedName, final String comment, final Line.Attr... attrs)
 	{
 		if (attrs.length == 0)
 		{
-			return new Line(null, null, product, normalizedName, lineStyle(null, product, normalizedName), comment);
+			return new Line(null, network, product, normalizedName, lineStyle(network, product, normalizedName), comment);
 		}
 		else
 		{
 			final Set<Line.Attr> attrSet = new HashSet<Line.Attr>();
 			for (final Line.Attr attr : attrs)
 				attrSet.add(attr);
-			return new Line(null, null, product, normalizedName, lineStyle(null, product, normalizedName), attrSet, comment);
+			return new Line(null, network, product, normalizedName, lineStyle(network, product, normalizedName), attrSet, comment);
 		}
 	}
 }

--- a/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
@@ -592,10 +592,12 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider
 				// TODO is_reachable
 				// TODO disableTrainInfo
 				String administration = XmlPullUtil.optAttr(pp, "administration", null);
-				Pattern pattern = Pattern.compile("([^_]*)_*");
-				Matcher matcher = pattern.matcher(administration);
-				if (matcher.find()) {
-					administration = matcher.group(1);
+				if (administration != null) {
+					Pattern pattern = Pattern.compile("([^_]*)_*");
+					Matcher matcher = pattern.matcher(administration);
+					if (matcher.find()) {
+						administration = matcher.group(1);
+					}
 				}
 
 				if (!"cancel".equals(eDelay))

--- a/enabler/src/de/schildbach/pte/ShProvider.java
+++ b/enabler/src/de/schildbach/pte/ShProvider.java
@@ -19,6 +19,8 @@ package de.schildbach.pte;
 
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 import com.google.common.base.Charsets;
@@ -27,6 +29,7 @@ import de.schildbach.pte.dto.Location;
 import de.schildbach.pte.dto.LocationType;
 import de.schildbach.pte.dto.NearbyLocationsResult;
 import de.schildbach.pte.dto.Product;
+import de.schildbach.pte.dto.Style;
 
 /**
  * @author Andreas Schildbach
@@ -38,6 +41,7 @@ public class ShProvider extends AbstractHafasProvider
 	public ShProvider()
 	{
 		super(NetworkId.SH, API_BASE + "stboard.exe/dn", API_BASE + "ajax-getstop.exe/dn", API_BASE + "query.exe/dn", 10, Charsets.UTF_8);
+		setStyles(STYLES);
 	}
 
 	@Override
@@ -163,5 +167,51 @@ public class ShProvider extends AbstractHafasProvider
 		uri.append("&distance=").append(maxDistance != 0 ? maxDistance / 1000 : 50);
 		uri.append("&input=").append(normalizeStationId(id));
 		return htmlNearbyStations(uri.toString());
+	}
+
+	protected static final Map<String, Style> STYLES = new HashMap<String, Style>();
+
+	static {
+		// Busse Kiel
+		putKielBusStyle("1", new Style(Style.parseColor("#7288af"), Style.WHITE));
+		putKielBusStyle("2", new Style(Style.parseColor("#50bbb4"), Style.WHITE));
+		putKielBusStyle("5", new Style(Style.parseColor("#f39222"), Style.WHITE));
+		putKielBusStyle("6", new Style(Style.parseColor("#aec436"), Style.WHITE));
+		putKielBusStyle("8", new Style(Style.parseColor("#bcb261"), Style.WHITE));
+		putKielBusStyle("9", new Style(Style.parseColor("#c99c7d"), Style.WHITE));
+		putKielBusStyle("11", new Style(Style.parseColor("#f9b000"), Style.WHITE));
+		putKielBusStyle("22", new Style(Style.parseColor("#8ea48a"), Style.WHITE));
+		putKielBusStyle("31", new Style(Style.parseColor("#009ee3"), Style.WHITE));
+		putKielBusStyle("32", new Style(Style.parseColor("#009ee3"), Style.WHITE));
+		putKielBusStyle("33", new Style(Style.parseColor("#009ee3"), Style.WHITE));
+		putKielBusStyle("34", new Style(Style.parseColor("#009ee3"), Style.WHITE));
+		putKielBusStyle("41", new Style(Style.parseColor("#8ba5d6"), Style.WHITE));
+		putKielBusStyle("42", new Style(Style.parseColor("#8ba5d6"), Style.WHITE));
+		putKielBusStyle("50", new Style(Style.parseColor("#00a138"), Style.WHITE));
+		putKielBusStyle("51", new Style(Style.parseColor("#00a138"), Style.WHITE));
+		putKielBusStyle("52", new Style(Style.parseColor("#00a138"), Style.WHITE));
+		putKielBusStyle("60S", new Style(Style.parseColor("#92b4af"), Style.WHITE));
+		putKielBusStyle("60", new Style(Style.parseColor("#92b4af"), Style.WHITE));
+		putKielBusStyle("61", new Style(Style.parseColor("#9d1380"), Style.WHITE));
+		putKielBusStyle("62", new Style(Style.parseColor("#9d1380"), Style.WHITE));
+		putKielBusStyle("71", new Style(Style.parseColor("#777e6f"), Style.WHITE));
+		putKielBusStyle("72", new Style(Style.parseColor("#777e6f"), Style.WHITE));
+		putKielBusStyle("81", new Style(Style.parseColor("#00836e"), Style.WHITE));
+		putKielBusStyle("91", new Style(Style.parseColor("#947e62"), Style.WHITE));
+		putKielBusStyle("92", new Style(Style.parseColor("#947e62"), Style.WHITE));
+		putKielBusStyle("100", new Style(Style.parseColor("#d40a11"), Style.WHITE));
+		putKielBusStyle("101", new Style(Style.parseColor("#d40a11"), Style.WHITE));
+		putKielBusStyle("300", new Style(Style.parseColor("#cf94c2"), Style.WHITE));
+		putKielBusStyle("501", new Style(Style.parseColor("#0f3f93"), Style.WHITE));
+		putKielBusStyle("502", new Style(Style.parseColor("#0f3f93"), Style.WHITE));
+		putKielBusStyle("503", new Style(Style.parseColor("#0f3f93"), Style.WHITE));
+		putKielBusStyle("503S", new Style(Style.parseColor("#0f3f93"), Style.WHITE));
+		putKielBusStyle("512", new Style(Style.parseColor("#0f3f93"), Style.WHITE));
+		putKielBusStyle("512S", new Style(Style.parseColor("#0f3f93"), Style.WHITE));
+	}
+
+	private static void putKielBusStyle(String name, Style style) {
+		STYLES.put("AK|B" + name, style);
+		STYLES.put("KIEL|B" + name, style);
 	}
 }


### PR DESCRIPTION
I added line colors for the city buses in Kiel.
As there are probably multiple bus lines in Schleswig-Holstein with these names, I needed to add the ability to parse the `administration` attribute, which includes information about the operator of the line (`KIEL__` for KVG Kiel and `AK____` for Autokraft) and is saved in the `network` attribute of the line. This attribute is currently only implemented in the `xmlStationBoard` function as I don't know if it is available and how to implement it in the binary format for the trip queries.