### PR TITLE
Configure continuous integration using Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+# configuration for https://travis-ci.org/schildbach/public-transport-enabler
+language: java
+jdk: openjdk6


### PR DESCRIPTION
Builds will be visible at https://travis-ci.org/schildbach/public-transport-enabler