### PR TITLE
Add missing transportation system, as Tisseo network is also in fr-sw Navitia region.

### DIFF
--- a/enabler/src/de/schildbach/pte/FrenchSouthWestProvider.java
+++ b/enabler/src/de/schildbach/pte/FrenchSouthWestProvider.java
@@ -61,6 +61,11 @@ public class FrenchSouthWestProvider extends AbstractNavitiaProvider
 				// Batcub
 				return new Style(Shape.ROUNDED, Style.parseColor(color), computeForegroundColor(color));
 			}
+                        case SUBWAY:
+                        {
+                                // Toulouse subway (from Tisseo network)
+                                return new Style(Shape.ROUNDED, Style.parseColor(color), computeForegroundColor(color));
+                        }
 			default:
 				throw new IllegalArgumentException("Unhandled product: " + product);
 		}


### PR DESCRIPTION
Prevent a:
```
java.lang.IllegalArgumentException: Unhandled product: SUBWAY
     at de.schildbach.pte.FrenchSouthWestProvider.getLineStyle(FrenchSouthWestProvider.java:65)
```
...error. Spotted in Transportr (https://github.com/grote/Transportr/issues/137) by @grote 

thanks!