### PR TITLE
avoid invalid color code like "#"

### DIFF
--- a/enabler/src/de/schildbach/pte/dto/Style.java
+++ b/enabler/src/de/schildbach/pte/dto/Style.java
@@ -120,12 +120,16 @@ public class Style implements Serializable
 			{
 				// Set the alpha value
 				color |= 0x00000000ff000000;
+				return (int) color;
 			}
-			else if (colorString.length() != 9)
+			else if (colorString.length() == 9)
+			{
+				return (int) color;
+			}
+			else
 			{
 				throw new IllegalArgumentException("Unknown color");
 			}
-			return (int) color;
 		}
 		throw new IllegalArgumentException("Unknown color");
 	}


### PR DESCRIPTION
Sorry if this is not well designed as I am a newcomer, but it seemed to me that the code does something it shouldn't: the `color` value is returned even though the `IllegalArgumentException` has been returned (for example, when colorString has a value of just "#", which results in errors. (See for example https://github.com/stragu/public-transport-enabler/commit/da47f2f6a66c7ef7ec04812b1b4936bf24a1bddc#commitcomment-16374155, or https://github.com/grote/Transportr/blob/master/src/de/schildbach/pte/NzProvider.java#L49 for a check against that.)