### PR TITLE
Less network requests and no NPE when querying Navitia departures

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
@@ -647,11 +647,22 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider
 		try
 		{
 			final String lineId = line.getString("id");
-			final Product cachedProduct = lineProductCache.get(lineId);
-			if (cachedProduct != null)
-				return cachedProduct;
+			JSONObject mode;
 
-			final JSONObject mode = getLinePhysicalMode(lineId);
+			if (line.has("physical_modes"))
+			{
+				mode = line.getJSONArray("physical_modes").getJSONObject(0);
+			}
+			else
+			{
+				final Product cachedProduct = lineProductCache.get(lineId);
+				if(cachedProduct != null)
+					return cachedProduct;
+
+				// this makes a network request and is sometimes necessary
+				mode = getLinePhysicalMode(lineId);
+			}
+
 			final String modeId = mode.getString("id");
 			final Product product = parseLineProductFromMode(modeId);
 
@@ -927,7 +938,9 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider
 				final JSONObject route = jsonDeparture.getJSONObject("route");
 				final JSONObject jsonLine = route.getJSONObject("line");
 				final Line line = parseLine(jsonLine);
-				final Location destination = findLineDestination(stationDepartures.lines, line).destination;
+				final LineDestination lineDestination = findLineDestination(stationDepartures.lines, line);
+				Location destination = null;
+				if (lineDestination != null) destination = lineDestination.destination;
 
 				// Add departure to list.
 				final Departure departure = new Departure(plannedTime, null, line, null, destination, null, null);


### PR DESCRIPTION
The AbstractNavitiaProvider was making one network request per departure
it found, just to find the `Product`. This information is mostly
available in the second request it makes, so this should be taken when
available.

Also, in rare cases no destination can be found for a line. It should
not crash in these cases. This was also fixed within this commit.

Both of these issues might be problems with Navitia and should ideally
also get reported upstream.