### PR TITLE
Navitia: Support Ambiguous QueryTripsResult

### DIFF
--- a/enabler/test/de/schildbach/pte/live/AbstractNavitiaProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/AbstractNavitiaProviderLiveTest.java
@@ -224,6 +224,32 @@ public abstract class AbstractNavitiaProviderLiveTest extends AbstractProviderLi
 		print(result);
 	}
 
+	protected final void queryTripAmbiguousFrom(final Location from, final CharSequence to) throws IOException
+	{
+		final SuggestLocationsResult toResult = suggestLocations(to);
+		assertTrue(toResult.getLocations().size() > 0);
+
+		final QueryTripsResult result = queryTrips(from, null, toResult.getLocations().get(0), new Date(), true,
+				Product.ALL, WalkSpeed.NORMAL, Accessibility.NEUTRAL);
+		assertEquals(QueryTripsResult.Status.AMBIGUOUS, result.status);
+		assertTrue(result.ambiguousFrom != null);
+		assertTrue(result.ambiguousFrom.size() > 0);
+		print(result);
+	}
+
+	protected final void queryTripAmbiguousTo(final CharSequence from, final Location to) throws IOException
+	{
+		final SuggestLocationsResult fromResult = suggestLocations(from);
+		assertTrue(fromResult.getLocations().size() > 0);
+
+		final QueryTripsResult result = queryTrips(fromResult.getLocations().get(0), null, to, new Date(), true,
+				Product.ALL, WalkSpeed.NORMAL, Accessibility.NEUTRAL);
+		assertEquals(QueryTripsResult.Status.AMBIGUOUS, result.status);
+		assertTrue(result.ambiguousTo != null);
+		assertTrue(result.ambiguousTo.size() > 0);
+		print(result);
+	}
+
 	protected final void queryTripSlowWalk(final CharSequence from, final CharSequence to) throws IOException
 	{
 		final SuggestLocationsResult fromResult = suggestLocations(from);

--- a/enabler/test/de/schildbach/pte/live/ParisProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/ParisProviderLiveTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import de.schildbach.pte.ParisProvider;
+import de.schildbach.pte.dto.Location;
+import de.schildbach.pte.dto.LocationType;
 import de.schildbach.pte.dto.Point;
 
 /**
@@ -176,6 +178,18 @@ public class ParisProviderLiveTest extends AbstractNavitiaProviderLiveTest
 	public void queryTripUnknownTo() throws Exception
 	{
 		queryTripUnknownTo("secretan buttes chaumont paris");
+	}
+
+	@Test
+	public void queryTripAmbiguousFrom() throws Exception
+	{
+		queryTripAmbiguousFrom(new Location(LocationType.ANY, "ambiguous", null, "Eiffel"), "Gare St-Lazare");
+	}
+
+	@Test
+	public void queryTripAmbiguousTo() throws Exception
+	{
+		queryTripAmbiguousTo("Gare St-Lazare", new Location(LocationType.ANY, "ambiguous", null, "Eiffel"));
 	}
 
 	@Test


### PR DESCRIPTION
This adds support for returning ambiguous QueryTripsResult in Navitia providers and adds the corresponding live tests to the ParisProvider.