### PR TITLE
NVV accept all hostnames

### DIFF
--- a/enabler/src/de/schildbach/pte/NvvProvider.java
+++ b/enabler/src/de/schildbach/pte/NvvProvider.java
@@ -45,6 +45,7 @@ public class NvvProvider extends AbstractHafasProvider
 
 		setJsonGetStopsEncoding(Charsets.UTF_8);
 		setJsonNearbyLocationsEncoding(Charsets.UTF_8);
+		httpClient.setSslAcceptAllHostnames(true);
 	}
 
 	private static final String[] PLACES = { "Frankfurt (Main)", "Offenbach (Main)", "Mainz", "Wiesbaden", "Marburg", "Kassel", "Hanau", "Göttingen",

--- a/enabler/src/de/schildbach/pte/util/HttpClient.java
+++ b/enabler/src/de/schildbach/pte/util/HttpClient.java
@@ -36,6 +36,9 @@ import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSession;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +63,7 @@ public final class HttpClient
 	private String sessionCookieName = null;
 	@Nullable
 	private HttpCookie sessionCookie = null;
+	private boolean sslAcceptAllHostnames = false;
 
 	private static final String SCRAPE_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
 	public static final int SCRAPE_INITIAL_CAPACITY = 4096;
@@ -83,6 +87,11 @@ public final class HttpClient
 	public void setSessionCookieName(final String sessionCookieName)
 	{
 		this.sessionCookieName = sessionCookieName;
+	}
+
+	public void setSslAcceptAllHostnames(final boolean sslAcceptAllHostnames)
+	{
+		this.sslAcceptAllHostnames = sslAcceptAllHostnames;
 	}
 
 	public CharSequence get(final String url) throws IOException
@@ -133,6 +142,9 @@ public final class HttpClient
 		{
 			final URL url = new URL(urlStr);
 			final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+			if (connection instanceof HttpsURLConnection && sslAcceptAllHostnames)
+				((HttpsURLConnection) connection).setHostnameVerifier(SSL_ACCEPT_ALL_HOSTNAMES);
 
 			connection.setDoInput(true);
 			connection.setDoOutput(postRequest != null);
@@ -352,4 +364,12 @@ public final class HttpClient
 
 		return false;
 	}
+
+	private static final HostnameVerifier SSL_ACCEPT_ALL_HOSTNAMES = new HostnameVerifier()
+	{
+		public boolean verify(final String hostname, final SSLSession session)
+		{
+			return true;
+		}
+	};
 }

--- a/enabler/test/de/schildbach/pte/live/AbstractProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/AbstractProviderLiveTest.java
@@ -21,19 +21,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.Properties;
 import java.util.Set;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 import de.schildbach.pte.NetworkProvider;
 import de.schildbach.pte.NetworkProvider.Accessibility;
@@ -56,8 +49,6 @@ public abstract class AbstractProviderLiveTest
 
 	public AbstractProviderLiveTest(final NetworkProvider provider)
 	{
-		disableSslCertificateValidation();
-
 		this.provider = provider;
 	}
 
@@ -171,43 +162,4 @@ public abstract class AbstractProviderLiveTest
 			throw new RuntimeException(x);
 		}
 	}
-
-	private static void disableSslCertificateValidation()
-	{
-		try
-		{
-			final SSLContext sslContext = SSLContext.getInstance("SSL");
-			sslContext.init(null, TRUST_ALL_CERTS, null);
-			HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
-			HttpsURLConnection.setDefaultHostnameVerifier(ACCEPT_ALL_HOSTNAMES);
-		}
-		catch (final Exception x)
-		{
-			throw new RuntimeException(x);
-		}
-	}
-
-	private static final TrustManager[] TRUST_ALL_CERTS = new TrustManager[] { new X509TrustManager()
-	{
-		public X509Certificate[] getAcceptedIssuers()
-		{
-			return null;
-		}
-
-		public void checkClientTrusted(final X509Certificate[] certs, final String authType)
-		{
-		}
-
-		public void checkServerTrusted(final X509Certificate[] certs, final String authType)
-		{
-		}
-	} };
-
-	private static final HostnameVerifier ACCEPT_ALL_HOSTNAMES = new HostnameVerifier()
-	{
-		public boolean verify(final String hostname, final SSLSession session)
-		{
-			return true;
-		}
-	};
 }


### PR DESCRIPTION
NVV: Accept all hostnames for SSL certificate validation, but still validate the certificate itself.

Re-enable SSL certificate validation for live tests.