### PR TITLE
VgnProvider: restore previous behavior

### DIFF
--- a/enabler/src/de/schildbach/pte/VgnProvider.java
+++ b/enabler/src/de/schildbach/pte/VgnProvider.java
@@ -59,7 +59,7 @@ public class VgnProvider extends AbstractEfaProvider {
 
     @Override
     public SuggestLocationsResult suggestLocations(final CharSequence constraint) throws IOException {
-        return xmlStopfinderRequest(new Location(LocationType.STATION, null, null, constraint.toString()));
+        return xmlStopfinderRequest(new Location(LocationType.ANY, null, null, constraint.toString()));
     }
 
     @Override


### PR DESCRIPTION
In b18ec864a9696d2fbe135e01fb3bc3addfc754dc you fixed a problem with umlauts in VgnProvider. You changed `LocationType.ANY` to `LocationType.STATION`. With this the search for starts and stops in both Transportr and Öffi stopped proposing POIs and similar. (I checked the currently distributed version of Öffi in the play store.) I think this was not intended (otherwise AbstractEFAProvider would have to be changed too).

This should restore previous behavior while keeping your fix.
I have mentioned this in grote/Transportr#258 and directly created a PR for you to merge if this is OK.