### PR TITLE
Use https for several providers

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
@@ -3036,7 +3036,8 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider {
         uri.append('y');
         uri.append("?performLocating=2&tpl=stop2json");
         uri.append("&look_stopclass=").append(allProductsInt());
-        uri.append("&look_nv=get_stopweight|yes");
+        // The | character needs to be urlencoded otherwise SNCB fails
+        uri.append("&look_nv=get_stopweight%7Cyes");
         // get_shortjson|yes
         // get_lines|yes
         // combinemode|2

--- a/enabler/src/de/schildbach/pte/MerseyProvider.java
+++ b/enabler/src/de/schildbach/pte/MerseyProvider.java
@@ -28,7 +28,7 @@ import de.schildbach.pte.dto.Product;
  * @author Andreas Schildbach
  */
 public class MerseyProvider extends AbstractEfaProvider {
-    private final static String API_BASE = "http://jp.merseytravel.gov.uk/nwm/";
+    private final static String API_BASE = "https://jp.merseytravel.gov.uk/nwm/";
 
     public MerseyProvider() {
         super(NetworkId.MERSEY, API_BASE);

--- a/enabler/src/de/schildbach/pte/MvvProvider.java
+++ b/enabler/src/de/schildbach/pte/MvvProvider.java
@@ -34,7 +34,7 @@ import de.schildbach.pte.dto.Style;
  * @author Andreas Schildbach
  */
 public class MvvProvider extends AbstractEfaProvider {
-    private static final String API_BASE = "http://efa.mvv-muenchen.de/mobile/";
+    private static final String API_BASE = "https://efa.mvv-muenchen.de/mobile/";
 
     public MvvProvider() {
         this(API_BASE);

--- a/enabler/src/de/schildbach/pte/NasaProvider.java
+++ b/enabler/src/de/schildbach/pte/NasaProvider.java
@@ -33,7 +33,7 @@ import de.schildbach.pte.util.StringReplaceReader;
  * @author Andreas Schildbach
  */
 public class NasaProvider extends AbstractHafasProvider {
-    private static final String API_BASE = "http://reiseauskunft.insa.de/bin/";
+    private static final String API_BASE = "https://reiseauskunft.insa.de/bin/";
     private static final Product[] PRODUCTS_MAP = { Product.HIGH_SPEED_TRAIN, Product.HIGH_SPEED_TRAIN,
             Product.REGIONAL_TRAIN, Product.REGIONAL_TRAIN, Product.SUBURBAN_TRAIN, Product.TRAM, Product.BUS,
             Product.ON_DEMAND };

--- a/enabler/src/de/schildbach/pte/NsProvider.java
+++ b/enabler/src/de/schildbach/pte/NsProvider.java
@@ -31,7 +31,7 @@ import de.schildbach.pte.dto.Product;
  * @author Andreas Schildbach
  */
 public class NsProvider extends AbstractHafasProvider {
-    private static final String API_BASE = "http://hafas.bene-system.com/bin/";
+    private static final String API_BASE = "https://hafas.bene-system.com/bin/";
     private static final Product[] PRODUCTS_MAP = { Product.HIGH_SPEED_TRAIN, Product.HIGH_SPEED_TRAIN,
             Product.HIGH_SPEED_TRAIN, Product.REGIONAL_TRAIN, Product.SUBURBAN_TRAIN, Product.BUS, Product.FERRY,
             Product.SUBWAY, Product.TRAM, Product.ON_DEMAND };

--- a/enabler/src/de/schildbach/pte/NvbwProvider.java
+++ b/enabler/src/de/schildbach/pte/NvbwProvider.java
@@ -35,8 +35,8 @@ import de.schildbach.pte.dto.QueryTripsResult;
  * @author Andreas Schildbach
  */
 public class NvbwProvider extends AbstractEfaProvider {
-    private final static String API_BASE = "http://www.efa-bw.de/nvbw/"; // no intermeditate stops
-    private final static String API_BASE_MOBILE = "http://www.efa-bw.de/android/";
+    private final static String API_BASE = "https://www.efa-bw.de/nvbw/"; // no intermeditate stops
+    private final static String API_BASE_MOBILE = "https://www.efa-bw.de/android/";
 
     // http://efa2.naldo.de/naldo/
 

--- a/enabler/src/de/schildbach/pte/SncbProvider.java
+++ b/enabler/src/de/schildbach/pte/SncbProvider.java
@@ -33,7 +33,7 @@ import de.schildbach.pte.dto.Product;
  * @author Andreas Schildbach
  */
 public class SncbProvider extends AbstractHafasProvider {
-    private static final String API_BASE = "http://www.belgianrail.be/jp/sncb-nmbs-routeplanner/";
+    private static final String API_BASE = "https://www.belgianrail.be/jp/sncb-nmbs-routeplanner/";
     // http://hari.b-rail.be/hafas/bin/
     private static final Product[] PRODUCTS_MAP = { Product.HIGH_SPEED_TRAIN, null, Product.HIGH_SPEED_TRAIN, null,
             null, Product.BUS, Product.REGIONAL_TRAIN, null, Product.SUBWAY, Product.BUS, Product.TRAM, null, null,

--- a/enabler/src/de/schildbach/pte/VrrProvider.java
+++ b/enabler/src/de/schildbach/pte/VrrProvider.java
@@ -37,7 +37,7 @@ import de.schildbach.pte.dto.Style.Shape;
  * @author Andreas Schildbach
  */
 public class VrrProvider extends AbstractEfaProvider {
-    private static final String API_BASE = "http://efa.vrr.de/standard/";
+    private static final String API_BASE = "https://efa.vrr.de/standard/";
 
     // http://app.vrr.de/companion-vrr/
 


### PR DESCRIPTION
Some providers (MERSEY, MVV, NASA, NS, NVBW, SNCB and VRR) still use an insecure url while the tests still pass when using a secure url. This pull request changes them to use https instead.
