### PR TITLE
fix NPE in AbstractNavitiaProvider

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
@@ -966,8 +966,11 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
                             }
                         }
 
+                        String prevQueryUrlString = prevQueryUrl != null ? prevQueryUrl.toString() : null;
+                        String nextQueryUrlString = nextQueryUrl != null ? nextQueryUrl.toString() : null;
+
                         final QueryTripsResult result = new QueryTripsResult(resultHeader, url.build().toString(), from,
-                                null, to, new Context(from, to, prevQueryUrl.toString(), nextQueryUrl.toString()),
+                                null, to, new Context(from, to, prevQueryUrlString, nextQueryUrlString),
                                 new LinkedList<Trip>());
 
                         parseQueryTripsResult(head, from, to, result);


### PR DESCRIPTION
4f7bd832e68527a343710d69d11b179cd49116a6 introduced a NullPointerException in AbstractNavitiaProvider. The call to `Context()` in line 970 calls `prevQueryUrl.toString()` and `nextQueryUrl.toString()`.
The variables are however `null` in the case that the search returned only one result. The easiest way to reproduce this is searching for two very nearby locations. The result will then be one walk-route.
This commit fixes the NPE by restoring the old behavior and has been tested in Transportr.