### PR TITLE
Don't swallow trips in Navitia providers

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
@@ -875,7 +875,7 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
                 url.addQueryParameter("to", printLocation(to));
                 url.addQueryParameter("datetime", printDate(date));
                 url.addQueryParameter("datetime_represents", dep ? "departure" : "arrival");
-                url.addQueryParameter("count", Integer.toString(this.numTripsRequested));
+                url.addQueryParameter("min_nb_journeys", Integer.toString(this.numTripsRequested));
                 url.addQueryParameter("depth", "0");
 
                 // Set walking speed.


### PR DESCRIPTION
Use the `min_nb_journeys` parameter rather than the `count` parameter when requesting trips.

The `count` parameter causes Navitia to remove trips arbitrarily from the result which can look like a bug to the user when she knows a trip should be there, but it isn't.