### PR TITLE
NegentweeProvider: Skip trips that have cancellations

### DIFF
--- a/enabler/src/de/schildbach/pte/NegentweeProvider.java
+++ b/enabler/src/de/schildbach/pte/NegentweeProvider.java
@@ -622,8 +622,10 @@ public class NegentweeProvider extends AbstractNetworkProvider {
             for (int i = 0; i < trips.length(); i++) {
                 JSONObject trip = trips.getJSONObject(i);
 
-                // Skip impossible trips
-                if (trip.getJSONObject("realtimeInfo").getString("delays").equals("fatal"))
+                // Skip impossible or cancelled trips
+                JSONObject realtimeInfo = trip.optJSONObject("realtimeInfo");
+                if(realtimeInfo != null && ("fatal".equals(realtimeInfo.optString("delays"))
+                        || "cancellations".equals(realtimeInfo.optString("cancellations"))))
                     continue;
 
                 foundTrips.add(tripFromJSONObject(trip, from, to, disturbancesMap));


### PR DESCRIPTION
This should fix a nasty bug where cancelled trips were returned as if they were still possible.  