### PR TITLE
add getNumChanges

### DIFF
--- a/enabler/src/de/schildbach/pte/dto/Trip.java
+++ b/enabler/src/de/schildbach/pte/dto/Trip.java
@@ -150,6 +150,34 @@ public final class Trip implements Serializable {
         return maxTime;
     }
 
+    /** Number of Changes on the trip.
+     *
+     * Returns the variable numChanges if it is not null.
+     * If numChanges is null, it tries to reconstruct the number of changes where applicable.
+     * The number of changes for a Trip consisting of only individual Legs is null.
+     *
+     * @return Number of changes on the trip
+     */
+    @Nullable
+    public Integer getNumChanges() {
+        if (numChanges == null) {
+            Integer numCount = null;
+
+            for (final Leg leg : legs){
+                if (leg instanceof Public) {
+                    if (numCount == null) {
+                        numCount = 0;
+                    } else {
+                        numCount++;
+                    }
+                }
+            }
+            return numCount;
+        } else {
+            return numChanges;
+        }
+    }
+
     /** Returns true if no legs overlap, false otherwise. */
     public boolean isTravelable() {
         Date time = null;

--- a/enabler/test/de/schildbach/pte/dto/TripTest.java
+++ b/enabler/test/de/schildbach/pte/dto/TripTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte.dto;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+
+/**
+ * @author Patrick Kanzler
+ */
+public class TripTest {
+   private Trip getDummyTripForChanges(Integer changes, Boolean numChangesNull, Integer mode) {
+        Trip dummy;
+        Location from = new Location(LocationType.ANY, null);
+        Location to = new Location(LocationType.ANY, null);
+        List<Trip.Leg> legs = getDummyLegsForChanges(mode, changes);
+        if (numChangesNull) {
+            dummy = new Trip(null, from, to, legs, null, null, null);
+        } else {
+            dummy = new Trip(null, from, to, legs, null, null, changes);
+        }
+        return dummy;
+    }
+
+    private List<Trip.Leg> getDummyLegsForChanges(Integer mode, Integer changes) {
+        Location from = new Location(LocationType.ANY, null);
+        Location to = new Location(LocationType.ANY, null);
+        List<Trip.Leg> legs = new LinkedList<>();
+        Stop departureStop = new Stop(from, null, null, new Date(42), null);
+        Stop arrivalStop = new Stop(to, new Date(43), null, null, null);
+        Line dummyLine = new Line(null, null, null, null);
+
+        switch (mode){
+            case 0:
+                //only Public
+                for (int i = 0; i < changes+1; i++) {
+                    legs.add(new Trip.Public(dummyLine, null, departureStop, arrivalStop, null, null, null));
+                }
+                break;
+            case 1:
+                //only Individual
+                for (int i = 0; i < changes+1; i++) {
+                    legs.add(new Trip.Individual(Trip.Individual.Type.BIKE, from, new Date(42), to, new Date(43),null, 42));
+                }
+                break;
+            case 2:
+                //mixed
+                for (int i = 0; i < changes+1; i++) {
+                    if ((i%2)==0) {
+                        legs.add(new Trip.Individual(Trip.Individual.Type.BIKE, from, new Date(42), to, new Date(43), null, 42));
+                    } else {
+                        legs.add(new Trip.Public(dummyLine, null, departureStop, arrivalStop, null, null, null));
+                    }
+                }
+                break;
+            default:
+                break;
+        }
+        return legs;
+    }
+
+    @Test
+    public void getNumChangesNullPublic() {
+        Integer numChangesExpected = 0;
+        Trip dummy = getDummyTripForChanges(numChangesExpected, true, 0);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+
+        numChangesExpected = 1;
+        dummy = getDummyTripForChanges(numChangesExpected, true, 0);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+
+        numChangesExpected = 2;
+        dummy = getDummyTripForChanges(numChangesExpected, true, 0);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+    }
+
+    @Test
+    public void getNumChangesNotNullPublic() {
+        Integer numChangesExpected = 0;
+        Trip dummy = getDummyTripForChanges(numChangesExpected, false, 0);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+
+        numChangesExpected = 1;
+        dummy = getDummyTripForChanges(numChangesExpected, false, 0);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+
+        numChangesExpected = 2;
+        dummy = getDummyTripForChanges(numChangesExpected, false, 0);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+    }
+
+    @Test
+    public void getNumChangesNullIndividual() {
+        Integer numChangesExpected = 0;
+        Trip dummy = getDummyTripForChanges(numChangesExpected, true, 1);
+        Assert.assertNull(dummy.getNumChanges());
+
+        numChangesExpected = 1;
+        dummy = getDummyTripForChanges(numChangesExpected, true, 1);
+        Assert.assertNull(dummy.getNumChanges());
+
+        numChangesExpected = 2;
+        dummy = getDummyTripForChanges(numChangesExpected, true, 1);
+        Assert.assertNull(dummy.getNumChanges());
+    }
+
+    @Test
+    public void getNumChangesNotNullIndividual() {
+        Integer numChangesExpected = 0;
+        Trip dummy = getDummyTripForChanges(numChangesExpected, false, 1);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+
+        numChangesExpected = 1;
+        dummy = getDummyTripForChanges(numChangesExpected, false, 1);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+
+        numChangesExpected = 2;
+        dummy = getDummyTripForChanges(numChangesExpected, false, 1);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+    }
+
+    @Test
+    public void getNumChangesNullMixed() {
+        Integer numChangesExpected = 0;
+        Trip dummy = getDummyTripForChanges(numChangesExpected, true, 2);
+        Assert.assertNull(dummy.getNumChanges());
+
+        numChangesExpected = 1;
+        dummy = getDummyTripForChanges(numChangesExpected, true, 2);
+        numChangesExpected = numChangesExpected-1;
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+
+        numChangesExpected = 2;
+        dummy = getDummyTripForChanges(numChangesExpected, true, 2);
+        numChangesExpected = numChangesExpected-2;
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+
+        numChangesExpected = 3;
+        dummy = getDummyTripForChanges(numChangesExpected, true, 2);
+        numChangesExpected = numChangesExpected-2;
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+    }
+
+    @Test
+    public void getNumChangesNotNullMixed() {
+        Integer numChangesExpected = 0;
+        Trip dummy = getDummyTripForChanges(numChangesExpected, false, 2);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+
+        numChangesExpected = 1;
+        dummy = getDummyTripForChanges(numChangesExpected, false, 2);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+
+        numChangesExpected = 2;
+        dummy = getDummyTripForChanges(numChangesExpected, false, 2);
+        Assert.assertEquals(numChangesExpected, dummy.getNumChanges());
+    }
+
+}


### PR DESCRIPTION
Computes the number of changes on a trip for numChanges that is null.
I am not sure how to handle the case when two Public Legs are connected by an Individual. In this case this would be also counted as one change. At least DBProvider copies also has this behavior. All in all I think I copied the behavior of the other APIs. I compared with VGN and DB.

fixes #151