### PR TITLE
NriProvider: Update base url.

### DIFF
--- a/enabler/src/de/schildbach/pte/NriProvider.java
+++ b/enabler/src/de/schildbach/pte/NriProvider.java
@@ -36,7 +36,7 @@ import okhttp3.HttpUrl;
  * @author Andreas Schildbach
  */
 public class NriProvider extends AbstractHafasLegacyProvider {
-    private static final HttpUrl API_BASE = HttpUrl.parse("http://hafas.websrv05.reiseinfo.no/bin/dev/nri/");
+    private static final HttpUrl API_BASE = HttpUrl.parse("http://apiprod.reiseinfo.no/bin/");
     private static final Product[] PRODUCTS_MAP = { Product.HIGH_SPEED_TRAIN, Product.REGIONAL_TRAIN, Product.BUS,
             Product.TRAM, Product.SUBWAY, Product.FERRY, Product.FERRY, Product.FERRY };
 


### PR DESCRIPTION
This is a temporary fix for #159 that allows us to use the old api until Entur makes the new API official.

This patch passes all the NriProviderLiveTest cases _except_ the short trips test. I don't know what's causing it but it fails with the following exception:

    java.lang.IllegalStateException: error C19 Communication: Read failed
            at de.schildbach.pte.AbstractHafasLegacyProvider$2.onSuccessful(AbstractHafasLegacyProvider.java:835)

I just wanted to submit the pr now in case it's something obvious that @schildbach or anybody else can point out to me. Otherwise I'll keep debugging until I understand what's wrong.

Also note that I'm not using the authKey as mentioned in issue #159 