### PR TITLE
Navitia: Add Orlyval to Physical Modes

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
@@ -92,7 +92,7 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
     }
 
     private enum PhysicalMode {
-        AIR, BOAT, BUS, BUSRAPIDTRANSIT, COACH, FERRY, FUNICULAR, LOCALTRAIN, LONGDISTANCETRAIN, METRO, RAPIDTRANSIT, SHUTTLE, TAXI, TRAIN, TRAMWAY, TRAM, OTHER
+        AIR, BOAT, BUS, BUSRAPIDTRANSIT, COACH, FERRY, FUNICULAR, LOCALTRAIN, LONGDISTANCETRAIN, METRO, RAPIDTRANSIT, SHUTTLE, TAXI, TRAIN, TRAMWAY, TRAM, VAL, OTHER
     }
 
     @SuppressWarnings("serial")
@@ -609,6 +609,7 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
         case TRAIN:
         case LOCALTRAIN:
         case LONGDISTANCETRAIN:
+        case VAL:
             return Product.SUBURBAN_TRAIN;
         case TRAMWAY:
         case TRAM:

--- a/enabler/test/de/schildbach/pte/live/ParisProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/ParisProviderLiveTest.java
@@ -135,6 +135,11 @@ public class ParisProviderLiveTest extends AbstractNavitiaProviderLiveTest {
     }
 
     @Test
+    public void queryTripStationsOrlyval() throws Exception {
+        queryTrip("Orly Sud", "Gare De Lyon");
+    }
+
+    @Test
     public void queryTripStationsRapidTransit() throws Exception {
         queryTrip("Luxembourg Paris", "Antony Antony");
     }


### PR DESCRIPTION
Without this patch, connections with the orlyval train cause an IllegalArgumentException