### PR TITLE
Add GhanaProvider

### DIFF
--- a/enabler/src/de/schildbach/pte/GhanaProvider.java
+++ b/enabler/src/de/schildbach/pte/GhanaProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte;
+
+import okhttp3.HttpUrl;
+
+public class GhanaProvider extends AbstractNavitiaProvider {
+    private static String API_REGION = "gh";
+
+    public GhanaProvider(final HttpUrl apiBase, final String authorization) {
+        super(NetworkId.GHANA, apiBase, authorization);
+
+        setTimeZone("UTC");
+    }
+
+    public GhanaProvider(final String authorization) {
+        super(NetworkId.GHANA, authorization);
+
+        setTimeZone("UTC");
+    }
+
+    @Override
+    public String region() {
+        return API_REGION;
+    }
+
+}

--- a/enabler/src/de/schildbach/pte/NetworkId.java
+++ b/enabler/src/de/schildbach/pte/NetworkId.java
@@ -79,5 +79,8 @@ public enum NetworkId {
     ONTARIO, QUEBEC,
 
     // Australia
-    SYDNEY, AUSTRALIA
+    SYDNEY, AUSTRALIA,
+
+    // Africa
+    GHANA,
 }

--- a/enabler/test/de/schildbach/pte/live/GhanaProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/GhanaProviderLiveTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte.live;
+
+import org.junit.Test;
+
+import de.schildbach.pte.GhanaProvider;
+import de.schildbach.pte.dto.Point;
+
+import static org.junit.Assert.assertTrue;
+
+public class GhanaProviderLiveTest extends AbstractNavitiaProviderLiveTest {
+    public GhanaProviderLiveTest() {
+        super(new GhanaProvider(secretProperty("navitia.authorization")));
+    }
+
+    @Test
+    public void nearbyStationsAddress() throws Exception {
+        nearbyStationsAddress(5553473, -190438);
+    }
+
+    @Test
+    public void nearbyStationsStation() throws Exception {
+        nearbyStationsStation("stop_area:SA4980974759");
+    }
+
+    @Test
+    public void nearbyStationsDistance() throws Exception {
+        nearbyStationsStationDistance("stop_area:SA5036738888");
+    }
+
+    @Test
+    public void nearbyStationsInvalidStation() throws Exception {
+        nearbyStationsInvalidStation("stop_area:SC5031328601");
+    }
+
+    @Test
+    public void queryDeparturesEquivsFalse() throws Exception {
+        queryDeparturesEquivsFalse("stop_point:5005030178");
+    }
+
+    @Test
+    public void queryDeparturesStopArea() throws Exception {
+        queryDeparturesStopArea("stop_area:SA5031328607");
+    }
+
+    @Test
+    public void queryDeparturesEquivsTrue() throws Exception {
+        queryDeparturesEquivsTrue("stop_area:SA5031328607");
+    }
+
+    @Test
+    public void queryDeparturesInvalidStation() throws Exception {
+        queryDeparturesInvalidStation("stop_point:RTP:5005030178");
+    }
+
+    @Test
+    public void suggestLocations() throws Exception {
+        suggestLocationsFromName("mark");
+    }
+
+    @Test
+    public void suggestLocationsNoLocation() throws Exception {
+        suggestLocationsNoLocation("bellevilleadasdjkaskd");
+    }
+
+    @Test
+    public void queryTripStations() throws Exception {
+        queryTrip("College", "Market");
+    }
+
+    @Test
+    public void queryTripUnknownFrom() throws Exception {
+        queryTripUnknownFrom("Market");
+    }
+
+    @Test
+    public void queryTripUnknownTo() throws Exception {
+        queryTripUnknownTo("Market");
+    }
+
+    @Test
+    public void queryMoreTrips() throws Exception {
+        queryMoreTrips("College", "Market");
+    }
+
+    @Test
+    public void getArea() throws Exception {
+        final Point[] polygon = provider.getArea();
+        assertTrue(polygon.length > 0);
+    }
+
+}


### PR DESCRIPTION
This is similar to #146 in the sense that this work came out of a local initiative to map public transport data in a region where otherwise no information and no apps exist. In Accra, the public transport is even informal without fixed schedules. The data was entered into OpenStreetMap and a GTFS file generated with [osm2gtfs](https://github.com/grote/osm2gtfs). This file is then processed by Navitia that offers the routing server for the data.

![mapping party](https://pbs.twimg.com/media/DMPrxd8X0AA2tY6.jpg:large)

This PR is mostly for inclusion in Transportr. It is not a request for adding Ghana support to Oeffi.