### PR TITLE
Navitia: Fix Sorting Order of Suggested Locations and Address Names

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
@@ -208,6 +208,19 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
         return name;
     }
 
+    /**
+     * Navitia always formats the address label in the French way.
+     * This method can be used to display addresses in a localized way.
+     * It defaults to putting the house number behind the street name.
+     *
+     * @param name The name of the address. Usually a street name.
+     * @param houseNumber The house number of the address.
+     * @return the localized name of the address location
+     */
+    protected String getAddressName(final String name, final String houseNumber) {
+        return name + " " + houseNumber;
+    }
+
     private Location parsePlace(JSONObject location, PlaceType placeType) throws IOException {
         try {
             final LocationType type = getLocationType(placeType);
@@ -216,7 +229,14 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
                 id = location.getString("id");
             final JSONObject coord = location.getJSONObject("coord");
             final Point point = parseCoord(coord);
-            final String name = getLocationName(location.getString("name"));
+            final String placeName = location.getString("name");
+            String name;
+            if (placeType == PlaceType.ADDRESS) {
+                final String houseNumber = location.optString("house_number", "0");
+                name = houseNumber.equals("0") ? getAddressName(placeName, houseNumber) : placeName;
+            } else {
+                name = getLocationName(placeName);
+            }
             String place = null;
             if (location.has("administrative_regions")) {
                 JSONArray admin = location.getJSONArray("administrative_regions");

--- a/enabler/src/de/schildbach/pte/FranceNorthEastProvider.java
+++ b/enabler/src/de/schildbach/pte/FranceNorthEastProvider.java
@@ -75,4 +75,10 @@ public class FranceNorthEastProvider extends AbstractNavitiaProvider {
             throw new IllegalArgumentException("Unhandled product: " + product);
         }
     }
+
+    @Override
+    protected String getAddressName(final String name, final String houseNumber) {
+        return houseNumber + " " + name;
+    }
+
 }

--- a/enabler/src/de/schildbach/pte/FranceNorthWestProvider.java
+++ b/enabler/src/de/schildbach/pte/FranceNorthWestProvider.java
@@ -41,4 +41,10 @@ public class FranceNorthWestProvider extends AbstractNavitiaProvider {
     public String region() {
         return API_REGION;
     }
+
+    @Override
+    protected String getAddressName(final String name, final String houseNumber) {
+        return houseNumber + " " + name;
+    }
+
 }

--- a/enabler/src/de/schildbach/pte/FranceSouthEastProvider.java
+++ b/enabler/src/de/schildbach/pte/FranceSouthEastProvider.java
@@ -76,4 +76,10 @@ public class FranceSouthEastProvider extends AbstractNavitiaProvider {
             return super.getLineStyle(network, product, code, color);
         }
     }
+
+    @Override
+    protected String getAddressName(final String name, final String houseNumber) {
+        return houseNumber + " " + name;
+    }
+
 }

--- a/enabler/src/de/schildbach/pte/FranceSouthWestProvider.java
+++ b/enabler/src/de/schildbach/pte/FranceSouthWestProvider.java
@@ -76,4 +76,10 @@ public class FranceSouthWestProvider extends AbstractNavitiaProvider {
             return super.getLineStyle(network, product, code, color);
         }
     }
+
+    @Override
+    protected String getAddressName(final String name, final String houseNumber) {
+        return houseNumber + " " + name;
+    }
+
 }

--- a/enabler/src/de/schildbach/pte/ParisProvider.java
+++ b/enabler/src/de/schildbach/pte/ParisProvider.java
@@ -89,4 +89,10 @@ public class ParisProvider extends AbstractNavitiaProvider {
     protected String getLocationName(String name) {
         return WordUtils.capitalizeFully(name);
     }
+
+    @Override
+    protected String getAddressName(final String name, final String houseNumber) {
+        return houseNumber + " " + name;
+    }
+
 }


### PR DESCRIPTION
The navitia developers have informed me that the "quality" of
auto-completion results is deprecated and already meaningless.
Also, we had a wrong inverse sorting order before. The only thing that
matters is the sort order in which the results are returned.
This commit fixes the sort order accordingly.

Similiarly broken was the way we displayed addresses. The house number
was missing from the location name. This commit adds the house number
behind the street name if available and gives a way to define other
formats like in France where the house number comes before the street
name.

Last but not least, some `@Nullable` annotations were added to modified
classes to highlight existing null pointer problems and to make it
easier for future developers to become aware of them.