### PR TITLE
Navitia: Fix sort order of suggested locations

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
@@ -845,10 +845,11 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
 
             if (head.has("places")) {
                 final JSONArray places = head.getJSONArray("places");
+                final int numPlaces = places.length();
 
-                for (int i = 0; i < places.length(); ++i) {
+                for (int i = 0; i < numPlaces; ++i) {
                     final JSONObject place = places.getJSONObject(i);
-                    final int priority = place.optInt("quality", 0);
+                    final int priority = numPlaces - i; // "quality" found in JSON is deprecated, only sort order matters
 
                     // Add location to station list.
                     final Location location = parseLocation(place);


### PR DESCRIPTION
The navitia developers have informed me that the "quality" of
auto-completion results is deprecated and already meaningless.
Also, we had a wrong inverse sorting order before. The only thing that
matters is the sort order in which the results are returned.
This commit fixes the sort order accordingly.