### PR TITLE
Navitia: Add Brazil providers

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
@@ -721,6 +721,9 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
 
         try {
             final JSONObject head = new JSONObject(page.toString());
+            if (head.has("error")) {
+                return new NearbyLocationsResult(resultHeader, Status.INVALID_ID);
+            }
 
             final JSONObject pagination = head.getJSONObject("pagination");
             final int nbResults = pagination.getInt("total_result");

--- a/enabler/src/de/schildbach/pte/BrFloripaProvider.java
+++ b/enabler/src/de/schildbach/pte/BrFloripaProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte;
+
+import javax.annotation.Nullable;
+
+import okhttp3.HttpUrl;
+
+/**
+ * @author Torsten Grote
+ */
+public class BrFloripaProvider extends AbstractNavitiaProvider
+{
+	private static final String API_REGION = "br-floripa";
+
+	public BrFloripaProvider(final HttpUrl api, @Nullable final String authorization)
+	{
+		super(NetworkId.BRFLORIPA, api, authorization);
+
+		setTimeZone("America/Sao_Paulo");
+	}
+
+	@Override
+	public String region()
+	{
+		return API_REGION;
+	}
+
+}

--- a/enabler/src/de/schildbach/pte/BrProvider.java
+++ b/enabler/src/de/schildbach/pte/BrProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte;
+
+
+import de.schildbach.pte.dto.Product;
+import de.schildbach.pte.dto.Style;
+import de.schildbach.pte.dto.Style.Shape;
+
+/**
+ * @author Torsten Grote
+ */
+public class BrProvider extends AbstractNavitiaProvider
+{
+	private static final String API_REGION = "br";
+
+	public BrProvider(final String authorization)
+	{
+		super(NetworkId.BR, authorization);
+
+		setTimeZone("America/Sao_Paulo");
+	}
+
+	@Override
+	public String region()
+	{
+		return API_REGION;
+	}
+
+	@Override
+	protected Style getLineStyle(final String network, final Product product, final String code, final String color)
+	{
+		final Style defaultStyle = Standard.STYLES.get(product);
+		int bc = defaultStyle.backgroundColor;
+		int fc = defaultStyle.foregroundColor;
+		if(color != null) {
+			bc = Style.parseColor(color);
+			fc = computeForegroundColor(color);
+		}
+
+		switch (product)
+		{
+			case SUBURBAN_TRAIN:
+			{
+				return new Style(Shape.CIRCLE, bc, fc);
+			}
+			case SUBWAY:
+			{
+				return new Style(Shape.CIRCLE, bc, fc);
+			}
+			case TRAM:
+			{
+				return new Style(Shape.RECT, bc, fc);
+			}
+			case BUS:
+			{
+				return new Style(Shape.RECT, bc, fc);
+			}
+			default:
+				return new Style(bc, fc);
+		}
+	}
+}

--- a/enabler/src/de/schildbach/pte/NetworkId.java
+++ b/enabler/src/de/schildbach/pte/NetworkId.java
@@ -83,4 +83,8 @@ public enum NetworkId {
 
     // Africa
     GHANA,
+
+    // Brazil
+    BR, BRFLORIPA,
+
 }

--- a/enabler/test/de/schildbach/pte/live/BrFloripaProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/BrFloripaProviderLiveTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte.live;
+
+import org.junit.Test;
+
+import de.schildbach.pte.BrFloripaProvider;
+import de.schildbach.pte.BrProvider;
+import de.schildbach.pte.dto.Point;
+import okhttp3.HttpUrl;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Torsten Grote
+ */
+public class BrFloripaProviderLiveTest extends AbstractNavitiaProviderLiveTest {
+
+	public BrFloripaProviderLiveTest() {
+		super(new BrFloripaProvider(HttpUrl.parse("https://transportr.grobox.de/api/v1/"), null));
+	}
+
+	@Test
+	public void nearbyStationsAddress() throws Exception {
+		nearbyStationsAddress(-27597000, -48553000);
+	}
+
+	@Test
+	public void nearbyStationsStation() throws Exception {
+		nearbyStationsStation("stop_point:43719878");
+	}
+
+	@Test
+	public void nearbyStationsInvalidStation() throws Exception {
+		nearbyStationsInvalidStation("stop_point:3719878");
+	}
+
+	@Test
+	public void queryDeparturesEquivsFalse() throws Exception {
+		queryDeparturesEquivsFalse("stop_point:43719878");
+	}
+
+	@Test
+	public void queryDeparturesInvalidStation() throws Exception {
+		queryDeparturesInvalidStation("stop_point:OWX:SP:6911");
+	}
+
+	@Test
+	public void suggestLocations() throws Exception {
+		suggestLocationsFromName("Lagoa");
+	}
+
+	@Test
+	public void queryTripStations() throws Exception {
+		queryTrip("Rua da Capela", "Bola de Neve Church");
+	}
+
+	@Test
+	public void queryMoreTrips() throws Exception {
+		queryMoreTrips("CELESC", "SC-406");
+	}
+
+	@Test
+	public void getArea() throws Exception {
+		final Point[] polygon = provider.getArea();
+		assertTrue(polygon.length > 0);
+	}
+
+}

--- a/enabler/test/de/schildbach/pte/live/BrProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/BrProviderLiveTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte.live;
+
+import org.junit.Test;
+
+import de.schildbach.pte.BrProvider;
+import de.schildbach.pte.dto.Point;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Torsten Grote
+ */
+public class BrProviderLiveTest extends AbstractNavitiaProviderLiveTest {
+
+	public BrProviderLiveTest() {
+		super(new BrProvider(secretProperty("navitia.authorization")));
+	}
+
+	@Test
+	public void nearbyStationsAddress() throws Exception {
+		// Sao Paulo
+		nearbyStationsAddress(-23547900, -46635200);
+	}
+
+	@Test
+	public void nearbyStationsAddress2() throws Exception {
+		// Rio de Janeiro
+		nearbyStationsAddress(-22905300, -43179500);
+	}
+
+	@Test
+	public void nearbyStationsStation() throws Exception {
+		nearbyStationsStation("stop_point:OIO:SP:18255914");
+	}
+
+	@Test
+	public void nearbyStationsInvalidStation() throws Exception {
+		nearbyStationsInvalidStation("stop_point:OIO:SPX:18255914");
+	}
+
+	@Test
+	public void queryDeparturesEquivsFalse() throws Exception {
+		queryDeparturesEquivsFalse("stop_point:OSA:SP:800016608");
+	}
+
+	@Test
+	public void queryDeparturesInvalidStation() throws Exception {
+		queryDeparturesInvalidStation("stop_point:OWX:SP:6911");
+	}
+
+	@Test
+	public void suggestLocations() throws Exception {
+		suggestLocationsFromName("Republica");
+	}
+
+	@Test
+	public void queryTripStations() throws Exception {
+		queryTrip("Benjamim Constant", "Avenida Paulista");
+	}
+
+	@Test
+	public void queryMoreTrips() throws Exception {
+		queryMoreTrips("Republica", "Avenida Paulista");
+	}
+
+	@Test
+	public void getArea() throws Exception {
+		final Point[] polygon = provider.getArea();
+		assertTrue(polygon.length > 0);
+	}
+
+}


### PR DESCRIPTION
Currently working in São Paulo, Rio de Janeiro, Belo Horizonte and Porto Alegre.

Both providers have been used in Transportr already. Time to upstream.