### PR TITLE
Navitia: Add Spain Provider

### DIFF
--- a/enabler/src/de/schildbach/pte/NetworkId.java
+++ b/enabler/src/de/schildbach/pte/NetworkId.java
@@ -83,4 +83,8 @@ public enum NetworkId {
 
     // Africa
     GHANA,
+
+    // Spain
+    SPAIN,
+
 }

--- a/enabler/src/de/schildbach/pte/SpainProvider.java
+++ b/enabler/src/de/schildbach/pte/SpainProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte;
+
+public class SpainProvider extends AbstractNavitiaProvider
+{
+	private static final String API_REGION = "es";
+
+	public SpainProvider(final String authorization)
+	{
+		super(NetworkId.SPAIN, authorization);
+
+		setTimeZone("Europe/Spain");
+	}
+
+	@Override
+	public String region()
+	{
+		return API_REGION;
+	}
+
+}

--- a/enabler/test/de/schildbach/pte/live/SpainProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/SpainProviderLiveTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte.live;
+
+import org.junit.Test;
+
+import de.schildbach.pte.SpainProvider;
+import de.schildbach.pte.dto.Point;
+
+import static org.junit.Assert.assertTrue;
+
+public class SpainProviderLiveTest extends AbstractNavitiaProviderLiveTest {
+
+    public SpainProviderLiveTest() {
+        super(new SpainProvider(secretProperty("navitia.authorization")));
+    }
+
+    @Test
+    public void nearbyStationsAddress() throws Exception {
+        // Valencia
+        nearbyStationsAddress(39473600, -371100);
+    }
+
+    @Test
+    public void nearbyStationsAddress2() throws Exception {
+        // Madrid
+        nearbyStationsAddress(40410400, -3702400);
+    }
+
+    @Test
+    public void nearbyStationsStation() throws Exception {
+        nearbyStationsStation("stop_point:E38:SP:2223");
+    }
+
+    @Test
+    public void nearbyStationsInvalidStation() throws Exception {
+        nearbyStationsInvalidStation("stop_point:EX38:SP:2223");
+    }
+
+    @Test
+    public void queryDeparturesEquivsFalse() throws Exception {
+        queryDeparturesEquivsFalse("stop_point:E38:SP:2223");
+    }
+
+    @Test
+    public void queryDeparturesInvalidStation() throws Exception {
+        queryDeparturesInvalidStation("stop_point:OWX:SP:6911");
+    }
+
+    @Test
+    public void suggestLocations() throws Exception {
+        suggestLocationsFromName("Turia");
+    }
+
+    @Test
+    public void queryTripStations() throws Exception {
+        queryTrip("Benimaclet", "Nou d'Octubre");
+    }
+
+    @Test
+    public void queryMoreTrips() throws Exception {
+        queryMoreTrips("Valencia Sud", "Faitanar");
+    }
+
+    @Test
+    public void getArea() throws Exception {
+        final Point[] polygon = provider.getArea();
+        assertTrue(polygon.length > 0);
+    }
+
+
+}


### PR DESCRIPTION
This was used in Transportr for some time and I used in it Valencia a couple of times.

The usual issues with Navitia based providers that cover a large region apply:
* quality of auto-complete results is bad
* sometimes validity of sub-regions expire and stop working