### PR TITLE
KVV: new endpoint

### DIFF
--- a/enabler/src/de/schildbach/pte/KvvProvider.java
+++ b/enabler/src/de/schildbach/pte/KvvProvider.java
@@ -34,14 +34,17 @@ import okhttp3.HttpUrl;
  * @author Andreas Schildbach
  */
 public class KvvProvider extends AbstractEfaProvider {
-    private static final HttpUrl API_BASE = HttpUrl.parse("http://213.144.24.66/kvv2/");
+	private static final HttpUrl API_BASE = HttpUrl.parse("https://www.kvv.de/tunnelEfaDirect.php");
 
     public KvvProvider() {
         this(API_BASE);
     }
 
     public KvvProvider(final HttpUrl apiBase) {
-        super(NetworkId.KVV, apiBase);
+        super(NetworkId.KVV, apiBase.newBuilder().addQueryParameter("action", DEFAULT_DEPARTURE_MONITOR_ENDPOINT).build(),
+                apiBase.newBuilder().addQueryParameter("action", DEFAULT_TRIP_ENDPOINT).build(),
+                apiBase.newBuilder().addQueryParameter("action", DEFAULT_STOPFINDER_ENDPOINT).build(),
+                apiBase.newBuilder().addQueryParameter("action", DEFAULT_COORD_ENDPOINT).build());
 
         setStyles(STYLES);
         setSessionCookieName("HASESSIONID");


### PR DESCRIPTION
It seems like the KVV provider doesn't allow any requests through its old endpoint anymore, as all requests result in `400: Bad Request`. Instead, I found that the official website now uses the following url: [https://www.kvv.de/tunnelEfaDirect.php](https://www.kvv.de/tunnelEfaDirect.php) with the `action` query parameter set to the respective request method (eg. `XSLT_TRIP_REQUEST2` for trip requests). The host and first query parameter were the only things that had to be changed, all other requests parameters can be left untouched. Also, the responses seem to be the same.
I suspect that the original (ip-address) endpoint now only allows requests from the official server so that all _user_ requests can be encrypted using https.