### PR TITLE
Add Texas, USA provider

### DIFF
--- a/enabler/src/de/schildbach/pte/NetworkId.java
+++ b/enabler/src/de/schildbach/pte/NetworkId.java
@@ -76,7 +76,7 @@ public enum NetworkId {
     DUB,
 
     // United States
-    RTACHICAGO, OREGON,
+    RTACHICAGO, OREGON, TEXAS,
 
     // Canada
     ONTARIO, QUEBEC, BRITISHCOLUMBIA,

--- a/enabler/src/de/schildbach/pte/TexasProvider.java
+++ b/enabler/src/de/schildbach/pte/TexasProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte;
+
+import okhttp3.HttpUrl;
+
+/**
+ * @author Ojas Ahuja
+ */
+
+public class TexasProvider extends AbstractNavitiaProvider {
+    private static String API_REGION = "us-tx";
+
+    public TexasProvider(final HttpUrl apiBase, final String authorization) {
+        super(NetworkId.TEXAS, apiBase, authorization);
+        setTimeZone("America/Chicago");
+    }
+
+    public TexasProvider(final String authorization) {
+        super(NetworkId.TEXAS, authorization);
+        setTimeZone("America/Chicago");
+    }
+
+    @Override
+    public String region() {
+        return API_REGION;
+    }
+}

--- a/enabler/test/de/schildbach/pte/live/TexasProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/TexasProviderLiveTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte.live;
+
+import org.junit.Test;
+
+import de.schildbach.pte.TexasProvider;
+import de.schildbach.pte.dto.Location;
+
+/**
+ * @author Ojas Ahuja
+ */
+
+public class TexasProviderLiveTest extends AbstractNavitiaProviderLiveTest {
+    public TexasProviderLiveTest() {
+        super(new TexasProvider(secretProperty("navitia.authorization")));
+    }
+
+    @Test
+    public void nearbyStationsStation() throws Exception {
+        nearbyStationsStation("stop_point:OCM:SP:5567");
+    }
+
+    @Test
+    public void nearbyStationsByCoordinate() throws Exception {
+        queryNearbyStations(Location.coord(302745403, -977361964));
+    }
+
+    @Test
+    public void queryDeparturesInvalidStation() throws Exception {
+        queryDepartures("stop_point:OCM:SP:xxxx", false);
+    }
+
+    @Test
+    public void queryDepartures() throws Exception {
+        queryDepartures("OCM:SP:5567", false);
+    }
+
+    @Test
+    public void suggestLocations() throws Exception {
+        suggestLocations("Airport");
+    }
+}


### PR DESCRIPTION
This PR is a resubmit of #99 with fixed conflicts.

Navitia `us-tx` includes support for Austin (CapMetro), Dallas (Dallas Rapid Transit), Fort Worth (FWTA), Houston (Harris County Metro), and San Antonio (VIA).