### PR TITLE
Added Canberra, Australia Provider

### DIFF
--- a/.idea/libraries/Gradle__aopalliance_aopalliance_1_0.xml
+++ b/.idea/libraries/Gradle__aopalliance_aopalliance_1_0.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: aopalliance:aopalliance:1.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/aopalliance/aopalliance/1.0/235ba8b489512805ac13a8f9ea77a1ca5ebe3e8/aopalliance-1.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/aopalliance/aopalliance/1.0/4a4b6d692e17846a9f3da036438a7ac491d3c814/aopalliance-1.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__com_google_code_findbugs_jsr305_3_0_2.xml
+++ b/.idea/libraries/Gradle__com_google_code_findbugs_jsr305_3_0_2.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: com.google.code.findbugs:jsr305:3.0.2">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/25ea2e8b0c338a877313bd4672d3fe056ea78f0d/jsr305-3.0.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/b19b5927c2c25b6c70f093767041e641ae0b1b35/jsr305-3.0.2-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__com_google_errorprone_error_prone_annotations_2_1_3.xml
+++ b/.idea/libraries/Gradle__com_google_errorprone_error_prone_annotations_2_1_3.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: com.google.errorprone:error_prone_annotations:2.1.3">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.1.3/39b109f2cd352b2d71b52a3b5a1a9850e1dc304b/error_prone_annotations-2.1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.1.3/990fe1fd48078a2befecdfcebcad8e6e1bd195a0/error_prone_annotations-2.1.3-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__com_google_guava_guava_25_1_android.xml
+++ b/.idea/libraries/Gradle__com_google_guava_guava_25_1_android.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: com.google.guava:guava:25.1-android">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/25.1-android/bdaab946ca5ad20253502d873ba0c3313d141036/guava-25.1-android.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/25.1-android/a1fe5380cc1f2979e434c3b6ff43d69328ab4686/guava-25.1-android-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__com_google_j2objc_j2objc_annotations_1_1.xml
+++ b/.idea/libraries/Gradle__com_google_j2objc_j2objc_annotations_1_1.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: com.google.j2objc:j2objc-annotations:1.1">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/976d8d30bebc251db406f2bdb3eb01962b5685b3/j2objc-annotations-1.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/dcd31de68a90e41e336f6b7afce0d39285c433d7/j2objc-annotations-1.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__com_squareup_okhttp3_logging_interceptor_3_10_0.xml
+++ b/.idea/libraries/Gradle__com_squareup_okhttp3_logging_interceptor_3_10_0.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: com.squareup.okhttp3:logging-interceptor:3.10.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup.okhttp3/logging-interceptor/3.10.0/55f574ec622f65ac9c0e2e922d3ffa01dc4f139e/logging-interceptor-3.10.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup.okhttp3/logging-interceptor/3.10.0/255a9237ac6ac8ba15bb85006348d3fb0009a866/logging-interceptor-3.10.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__com_squareup_okhttp3_okhttp_3_10_0.xml
+++ b/.idea/libraries/Gradle__com_squareup_okhttp3_okhttp_3_10_0.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: com.squareup.okhttp3:okhttp:3.10.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup.okhttp3/okhttp/3.10.0/7ef0f1d95bf4c0b3ba30bbae25e0e562b05cf75e/okhttp-3.10.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup.okhttp3/okhttp/3.10.0/e99b7b608968f16b07104b93e62cb90701174d0/okhttp-3.10.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__com_squareup_okio_okio_1_14_0.xml
+++ b/.idea/libraries/Gradle__com_squareup_okio_okio_1_14_0.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: com.squareup.okio:okio:1.14.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup.okio/okio/1.14.0/102d7be47241d781ef95f1581d414b0943053130/okio-1.14.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup.okio/okio/1.14.0/e7c96b4fe5651490d8f3c022042940d743a3bdd9/okio-1.14.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__commons_logging_commons_logging_1_1_1.xml
+++ b/.idea/libraries/Gradle__commons_logging_commons_logging_1_1_1.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: commons-logging:commons-logging:1.1.1">
+    <CLASSES>
+      <root url="jar://$APPLICATION_HOME_DIR$/gradle/m2repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$APPLICATION_HOME_DIR$/gradle/m2repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__junit_junit_4_12.xml
+++ b/.idea/libraries/Gradle__junit_junit_4_12.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: junit:junit:4.12">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/junit/junit/4.12/2973d150c0dc1fefe998f834810d68f278ea58ec/junit-4.12.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/junit/junit/4.12/a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa/junit-4.12-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__net_sf_kxml_kxml2_2_3_0.xml
+++ b/.idea/libraries/Gradle__net_sf_kxml_kxml2_2_3_0.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: net.sf.kxml:kxml2:2.3.0">
+    <CLASSES>
+      <root url="jar://$APPLICATION_HOME_DIR$/gradle/m2repository/net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$APPLICATION_HOME_DIR$/gradle/m2repository/net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_checkerframework_checker_compat_qual_2_0_0.xml
+++ b/.idea/libraries/Gradle__org_checkerframework_checker_compat_qual_2_0_0.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.checkerframework:checker-compat-qual:2.0.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.checkerframework/checker-compat-qual/2.0.0/fc89b03860d11d6213d0154a62bcd1c2f69b9efa/checker-compat-qual-2.0.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.checkerframework/checker-compat-qual/2.0.0/eb7f7d588d0aef07a2c89178053c2a9e4613947f/checker-compat-qual-2.0.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_codehaus_jackson_jackson_core_asl_1_9_4.xml
+++ b/.idea/libraries/Gradle__org_codehaus_jackson_jackson_core_asl_1_9_4.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.codehaus.jackson:jackson-core-asl:1.9.4">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.jackson/jackson-core-asl/1.9.4/8d8b2a3e5bc77ee1be67d060b44ac77d48a27d6e/jackson-core-asl-1.9.4.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.jackson/jackson-core-asl/1.9.4/6900e0981e0cb1dbef3f5478fea10d08697943f0/jackson-core-asl-1.9.4-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_codehaus_jackson_jackson_mapper_asl_1_9_4.xml
+++ b/.idea/libraries/Gradle__org_codehaus_jackson_jackson_mapper_asl_1_9_4.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.codehaus.jackson:jackson-mapper-asl:1.9.4">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.jackson/jackson-mapper-asl/1.9.4/5206191b35112f50b8e25fcbd3f3b84e12e11cee/jackson-mapper-asl-1.9.4.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.jackson/jackson-mapper-asl/1.9.4/b02c74ecea713097e92b037a27cdf9bbd2d96615/jackson-mapper-asl-1.9.4-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_codehaus_mojo_animal_sniffer_annotations_1_14.xml
+++ b/.idea/libraries/Gradle__org_codehaus_mojo_animal_sniffer_annotations_1_14.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.codehaus.mojo:animal-sniffer-annotations:1.14">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.mojo/animal-sniffer-annotations/1.14/775b7e22fb10026eed3f86e8dc556dfafe35f2d5/animal-sniffer-annotations-1.14.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.mojo/animal-sniffer-annotations/1.14/886474da3f761d39fcbb723d97ecc5089e731f42/animal-sniffer-annotations-1.14-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_hamcrest_hamcrest_core_1_3.xml
+++ b/.idea/libraries/Gradle__org_hamcrest_hamcrest_core_1_3.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.hamcrest:hamcrest-core:1.3">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-core/1.3/42a25dc3219429f0e5d060061f71acb49bf010a0/hamcrest-core-1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-core/1.3/1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b/hamcrest-core-1.3-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_json_json_20090211.xml
+++ b/.idea/libraries/Gradle__org_json_json_20090211.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Gradle: org.json:json:20090211">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.json/json/20090211/c183aa3a2a6250293808bba12262c8920ce5a51c/json-20090211.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_slf4j_slf4j_api_1_7_25.xml
+++ b/.idea/libraries/Gradle__org_slf4j_slf4j_api_1_7_25.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.slf4j:slf4j-api:1.7.25">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.25/da76ca59f6a57ee3102f8f9bd9cee742973efa8a/slf4j-api-1.7.25.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.25/962153db4a9ea71b79d047dfd1b2a0d80d8f4739/slf4j-api-1.7.25-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_slf4j_slf4j_jdk14_1_7_25.xml
+++ b/.idea/libraries/Gradle__org_slf4j_slf4j_jdk14_1_7_25.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.slf4j:slf4j-jdk14:1.7.25">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-jdk14/1.7.25/bccda40ebc8067491b32a88f49615a747d20082d/slf4j-jdk14-1.7.25.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-jdk14/1.7.25/f62afc0e42c562f3afae648b95e755675102d3f9/slf4j-jdk14-1.7.25-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_springframework_spring_aop_3_1_0_RELEASE.xml
+++ b/.idea/libraries/Gradle__org_springframework_spring_aop_3_1_0_RELEASE.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.springframework:spring-aop:3.1.0.RELEASE">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-aop/3.1.0.RELEASE/5d998ce239b87cbf66fd18a01dad854de13e2f06/spring-aop-3.1.0.RELEASE.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-aop/3.1.0.RELEASE/78511dd53c1e04e2388be79229ddc5a579108a/spring-aop-3.1.0.RELEASE-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_springframework_spring_asm_3_1_0_RELEASE.xml
+++ b/.idea/libraries/Gradle__org_springframework_spring_asm_3_1_0_RELEASE.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.springframework:spring-asm:3.1.0.RELEASE">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-asm/3.1.0.RELEASE/de7cf38491d3243c98c7d61ccdb40756df92c6d1/spring-asm-3.1.0.RELEASE.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-asm/3.1.0.RELEASE/b442feee99993c71bdfedeba8e049863966034ce/spring-asm-3.1.0.RELEASE-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_springframework_spring_beans_3_1_0_RELEASE.xml
+++ b/.idea/libraries/Gradle__org_springframework_spring_beans_3_1_0_RELEASE.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.springframework:spring-beans:3.1.0.RELEASE">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-beans/3.1.0.RELEASE/d12bb11cc2469cca2d8ba33d86d188733544d7e0/spring-beans-3.1.0.RELEASE.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-beans/3.1.0.RELEASE/b59685ec9d53af4d5e9e522115eda33b4596cfb6/spring-beans-3.1.0.RELEASE-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_springframework_spring_context_3_1_0_RELEASE.xml
+++ b/.idea/libraries/Gradle__org_springframework_spring_context_3_1_0_RELEASE.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.springframework:spring-context:3.1.0.RELEASE">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-context/3.1.0.RELEASE/d36e9ab580dccc8311704bc11f2434f230bdec28/spring-context-3.1.0.RELEASE.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-context/3.1.0.RELEASE/b5b20b5c755ad748b607807a6f0e3e3479cdfe1d/spring-context-3.1.0.RELEASE-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_springframework_spring_context_support_3_1_0_RELEASE.xml
+++ b/.idea/libraries/Gradle__org_springframework_spring_context_support_3_1_0_RELEASE.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.springframework:spring-context-support:3.1.0.RELEASE">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-context-support/3.1.0.RELEASE/379bb71a6eb9f1a965cd7d6d94524deab2a3da07/spring-context-support-3.1.0.RELEASE.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-context-support/3.1.0.RELEASE/4b6e100cc17f62fdcdecd83e5eeeebd0641fbef9/spring-context-support-3.1.0.RELEASE-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_springframework_spring_core_3_1_0_RELEASE.xml
+++ b/.idea/libraries/Gradle__org_springframework_spring_core_3_1_0_RELEASE.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.springframework:spring-core:3.1.0.RELEASE">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-core/3.1.0.RELEASE/3a18c725dd321e457cfb48547d40c2862216bb3b/spring-core-3.1.0.RELEASE.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-core/3.1.0.RELEASE/f0bc10850fd7d7f7f5a8742b60e7e81551e9f3a9/spring-core-3.1.0.RELEASE-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_springframework_spring_expression_3_1_0_RELEASE.xml
+++ b/.idea/libraries/Gradle__org_springframework_spring_expression_3_1_0_RELEASE.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.springframework:spring-expression:3.1.0.RELEASE">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-expression/3.1.0.RELEASE/d226f5e14c7c775b97db275950786c083290b983/spring-expression-3.1.0.RELEASE.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-expression/3.1.0.RELEASE/e8191f9a849b984a403939a37de818b1b356e7e5/spring-expression-3.1.0.RELEASE-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_springframework_spring_web_3_1_0_RELEASE.xml
+++ b/.idea/libraries/Gradle__org_springframework_spring_web_3_1_0_RELEASE.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.springframework:spring-web:3.1.0.RELEASE">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-web/3.1.0.RELEASE/c50458fccc24b87170f6557765c6720a489b5eb2/spring-web-3.1.0.RELEASE.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-web/3.1.0.RELEASE/f7d078f44b8c1d77d0b639e74013ceecc1332124/spring-web-3.1.0.RELEASE-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Gradle__org_springframework_spring_webmvc_3_1_0_RELEASE.xml
+++ b/.idea/libraries/Gradle__org_springframework_spring_webmvc_3_1_0_RELEASE.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="Gradle: org.springframework:spring-webmvc:3.1.0.RELEASE">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-webmvc/3.1.0.RELEASE/9a9c88df8825ff3c2ecb79f7ac29ad1e229e6fd6/spring-webmvc-3.1.0.RELEASE.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-webmvc/3.1.0.RELEASE/ccd5ec5be1065cc70b03165db468c9a7064e751f/spring-webmvc-3.1.0.RELEASE-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/enabler/enabler.iml" filepath="$PROJECT_DIR$/.idea/modules/enabler/enabler.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/public-transport-enabler.iml" filepath="$PROJECT_DIR$/.idea/modules/public-transport-enabler.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/service/service.iml" filepath="$PROJECT_DIR$/.idea/modules/service/service.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules/enabler/enabler.iml
+++ b/.idea/modules/enabler/enabler.iml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id=":enabler" external.linked.project.path="$MODULE_DIR$/../../../enabler" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="public-transport-enabler" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/../../../enabler/build/classes/main" />
+    <output-test url="file://$MODULE_DIR$/../../../enabler/build/classes/test" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../../../enabler">
+      <sourceFolder url="file://$MODULE_DIR$/../../../enabler/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../enabler/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../enabler/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../enabler/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.10.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.slf4j:slf4j-jdk14:1.7.25" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.12" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.code.findbugs:jsr305:3.0.2" level="project" />
+    <orderEntry type="library" name="Gradle: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.j2objc:j2objc-annotations:1.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.errorprone:error_prone_annotations:2.1.3" level="project" />
+    <orderEntry type="library" name="Gradle: org.checkerframework:checker-compat-qual:2.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.14.0" level="project" />
+    <orderEntry type="library" name="Gradle: net.sf.kxml:kxml2:2.3.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.json:json:20090211" level="project" />
+    <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.25" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.guava:guava:25.1-android" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:logging-interceptor:3.10.0" level="project" />
+  </component>
+</module>

--- a/.idea/modules/public-transport-enabler.iml
+++ b/.idea/modules/public-transport-enabler.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="public-transport-enabler" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/../../build/classes/main" />
+    <output-test url="file://$MODULE_DIR$/../../build/classes/test" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../..">
+      <excludeFolder url="file://$MODULE_DIR$/../../.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/../../build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules/service/service.iml
+++ b/.idea/modules/service/service.iml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id=":service" external.linked.project.path="$MODULE_DIR$/../../../service" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="public-transport-enabler" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/../../../service/build/classes/main" />
+    <output-test url="file://$MODULE_DIR$/../../../service/build/classes/test" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../../../service">
+      <sourceFolder url="file://$MODULE_DIR$/../../../service/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../service/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../service/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../service/src/test/resources" type="java-test-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../service/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../service/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="enabler" />
+    <orderEntry type="library" name="Gradle: com.google.code.findbugs:jsr305:3.0.2" level="project" />
+    <orderEntry type="library" name="Gradle: aopalliance:aopalliance:1.0" level="project" />
+    <orderEntry type="library" name="Gradle: commons-logging:commons-logging:1.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-aop:3.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Gradle: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.j2objc:j2objc-annotations:1.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.errorprone:error_prone_annotations:2.1.3" level="project" />
+    <orderEntry type="library" name="Gradle: org.checkerframework:checker-compat-qual:2.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.14.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.codehaus.jackson:jackson-core-asl:1.9.4" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-web:3.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-expression:3.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-core:3.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-context-support:3.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-context:3.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-beans:3.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-asm:3.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Gradle: net.sf.kxml:kxml2:2.3.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.json:json:20090211" level="project" />
+    <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.25" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.guava:guava:25.1-android" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:logging-interceptor:3.10.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.10.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.codehaus.jackson:jackson-mapper-asl:1.9.4" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-webmvc:3.1.0.RELEASE" level="project" />
+  </component>
+</module>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/enabler/src/de/schildbach/pte/AustraliaProvider.java
+++ b/enabler/src/de/schildbach/pte/AustraliaProvider.java
@@ -32,6 +32,7 @@ public class AustraliaProvider extends AbstractNavitiaProvider {
     public static final String NETWORK_QLD = "TransLink";
     public static final String NETWORK_SA = "Adelaide Metro";
     public static final String NETWORK_WA = "Transperth";
+    public static final String NETWORK_ACT = "ACTION";
 
     private static final Map<String, Style> STYLES = new HashMap<>();
 

--- a/enabler/src/de/schildbach/pte/CanberraProvider.java
+++ b/enabler/src/de/schildbach/pte/CanberraProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte;
+
+import okhttp3.HttpUrl;
+
+/**
+ * @author Anish Lakhwara
+ */
+
+public class CanberraProvider extends AbstractNavitiaProvider {
+    private static String API_REGION = "au";
+
+    public TexasProvider(final HttpUrl apiBase, final String authorization) {
+        super(NetworkId.TEXAS, apiBase, authorization);
+        setTimeZone("Australia/Canberra");
+    }
+
+    public CanberraProvider(final String authorization) {
+        super(NetworkId.TEXAS, authorization);
+        setTimeZone("Australia/Canberra");
+    }
+
+    @Override
+    public String region() {
+        return API_REGION;
+    }
+}

--- a/enabler/src/de/schildbach/pte/CanberraProvider.java
+++ b/enabler/src/de/schildbach/pte/CanberraProvider.java
@@ -26,13 +26,13 @@ import okhttp3.HttpUrl;
 public class CanberraProvider extends AbstractNavitiaProvider {
     private static String API_REGION = "au";
 
-    public TexasProvider(final HttpUrl apiBase, final String authorization) {
-        super(NetworkId.TEXAS, apiBase, authorization);
+    public CanberraProvider(final HttpUrl apiBase, final String authorization) {
+        super(NetworkId.CANBERRA, apiBase, authorization);
         setTimeZone("Australia/Canberra");
     }
 
     public CanberraProvider(final String authorization) {
-        super(NetworkId.TEXAS, authorization);
+        super(NetworkId.CANBERRA, authorization);
         setTimeZone("Australia/Canberra");
     }
 

--- a/enabler/src/de/schildbach/pte/NetworkId.java
+++ b/enabler/src/de/schildbach/pte/NetworkId.java
@@ -82,7 +82,7 @@ public enum NetworkId {
     ONTARIO, QUEBEC, BRITISHCOLUMBIA,
 
     // Australia
-    SYDNEY, AUSTRALIA,
+    SYDNEY, CANBERRA, AUSTRALIA,
 
     // New Zealand
     NZ,

--- a/enabler/test/de/schildbach/pte/live/CanberraProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/CanberraProviderLiveTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte.live;
+
+import org.junit.Test;
+
+import de.schildbach.pte.CanberraProvider;
+import de.schildbach.pte.dto.Location;
+
+/**
+ * @author Anish Lakhwara
+ */
+
+public class CanberraProviderLiveTest extends AbstractNavitiaProviderLiveTest {
+    public CanberraProviderLiveTest() {
+        super(new CanberraProvider(secretProperty("navitia.authorization")));
+    }
+
+    @Test
+    public void nearbyStationsStation() throws Exception {
+        nearbyStationsStation("stop_point:OCN:SP:3353");
+    }
+
+    @Test
+    public void nearbyStationsByCoordinate() throws Exception {
+        queryNearbyStations(Location.coord(-352819, 1491289));
+    }
+
+    @Test
+    public void queryDeparturesInvalidStation() throws Exception {
+        queryDepartures("stop_point:OCN:SP:xxxx", false);
+    }
+
+    @Test
+    public void queryDepartures() throws Exception {
+        queryDepartures("OCN:SP:3353", false);
+    }
+
+    @Test
+    public void suggestLocations() throws Exception {
+        suggestLocations("Airport");
+    }
+}


### PR DESCRIPTION
This PR adds support for the bus network in Canberra Australia. 
Navitia includes support for the Transport Canberra network, which covers all of Canberra's buses (currently the only available public transport network)

I have not tested this yet, because I'm not entirely sure how to do that. This pull request was based on the Texas USA provider #194 