### PR TITLE
Fix issue with SSL certificate in VGS provider

### DIFF
--- a/enabler/src/de/schildbach/pte/VgsProvider.java
+++ b/enabler/src/de/schildbach/pte/VgsProvider.java
@@ -43,6 +43,7 @@ public class VgsProvider extends AbstractHafasLegacyProvider {
 
         setStationBoardHasStationTable(false);
         httpClient.setTrustAllCertificates(true);
+        httpClient.setSslAcceptAllHostnames(true);
     }
 
     @Override


### PR DESCRIPTION
When network providers don't know how to use SSL...

Already tested with LiveTests.