### PR TITLE
Add new VIA and REALTIME capabilities

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractEfaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractEfaProvider.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Currency;
 import java.util.Date;
@@ -95,6 +96,14 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider {
     protected static final String SERVER_PRODUCT = "efa";
     protected static final String COORD_FORMAT = "WGS84[DD.ddddd]";
     protected static final int COORD_FORMAT_TAIL = 7;
+
+    private final List CAPABILITIES = Arrays.asList(
+            Capability.SUGGEST_LOCATIONS,
+            Capability.NEARBY_LOCATIONS,
+            Capability.DEPARTURES,
+            Capability.TRIPS,
+            Capability.TRIPS_VIA
+    );
 
     private final HttpUrl departureMonitorEndpoint;
     private final HttpUrl tripEndpoint;
@@ -228,9 +237,10 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider {
         return this;
     }
 
+    // this should be overridden by networks not providing one of the default capabilities
     @Override
     protected boolean hasCapability(final Capability capability) {
-        return true;
+        return CAPABILITIES.contains(capability);
     }
 
     private final void appendCommonRequestParams(final HttpUrl.Builder url, final String outputFormat) {

--- a/enabler/src/de/schildbach/pte/AbstractEfaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractEfaProvider.java
@@ -102,7 +102,9 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider {
             Capability.NEARBY_LOCATIONS,
             Capability.DEPARTURES,
             Capability.TRIPS,
-            Capability.TRIPS_VIA
+            Capability.TRIPS_VIA,
+            Capability.DEPARTURES_REALTIME,
+            Capability.TRIPS_REALTIME
     );
 
     private final HttpUrl departureMonitorEndpoint;

--- a/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
@@ -20,6 +20,7 @@ package de.schildbach.pte;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -43,6 +44,14 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider {
     protected static final int DEFAULT_MAX_LOCATIONS = 50;
     protected static final int DEFAULT_MAX_DISTANCE = 20000;
 
+    private final List CAPABILITIES = Arrays.asList(
+            Capability.SUGGEST_LOCATIONS,
+            Capability.NEARBY_LOCATIONS,
+            Capability.DEPARTURES,
+            Capability.TRIPS,
+            Capability.TRIPS_VIA
+    );
+
     protected static final Logger log = LoggerFactory.getLogger(AbstractHafasProvider.class);
 
     private Product[] productsMap;
@@ -52,9 +61,10 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider {
         this.productsMap = productsMap;
     }
 
+    // this should be overridden by networks not providing one of the default capabilities
     @Override
     protected boolean hasCapability(final Capability capability) {
-        return true;
+        return CAPABILITIES.contains(capability);
     }
 
     protected final CharSequence productsString(final Set<Product> products) {

--- a/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractHafasProvider.java
@@ -49,7 +49,9 @@ public abstract class AbstractHafasProvider extends AbstractNetworkProvider {
             Capability.NEARBY_LOCATIONS,
             Capability.DEPARTURES,
             Capability.TRIPS,
-            Capability.TRIPS_VIA
+            Capability.TRIPS_VIA,
+            Capability.DEPARTURES_REALTIME,
+            Capability.TRIPS_REALTIME //not provided by networks using XML endpoint, hasCapability should be overridden there
     );
 
     protected static final Logger log = LoggerFactory.getLogger(AbstractHafasProvider.class);

--- a/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.LinkedList;
@@ -76,6 +77,13 @@ import okhttp3.HttpUrl;
 public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
     protected final static String SERVER_PRODUCT = "navitia";
     protected final static String SERVER_VERSION = "v1";
+
+    private final List CAPABILITIES = Arrays.asList(
+            Capability.SUGGEST_LOCATIONS,
+            Capability.NEARBY_LOCATIONS,
+            Capability.DEPARTURES,
+            Capability.TRIPS
+    );
 
     protected HttpUrl apiBase = HttpUrl.parse("https://api.navitia.io/").newBuilder().addPathSegment(SERVER_VERSION)
             .build();
@@ -679,13 +687,10 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
         }
     }
 
+    // this should be overridden by networks not providing one of the default capabilities
     @Override
     protected boolean hasCapability(final Capability capability) {
-        if (capability == Capability.SUGGEST_LOCATIONS || capability == Capability.NEARBY_LOCATIONS
-                || capability == Capability.DEPARTURES || capability == Capability.TRIPS)
-            return true;
-        else
-            return false;
+        return CAPABILITIES.contains(capability);
     }
 
     @Override

--- a/enabler/src/de/schildbach/pte/EireannProvider.java
+++ b/enabler/src/de/schildbach/pte/EireannProvider.java
@@ -49,6 +49,15 @@ public class EireannProvider extends AbstractHafasLegacyProvider {
     }
 
     @Override
+    protected boolean hasCapability(final Capability capability) {
+        // as this provider is using the XML endpoint, it does not have real-time information on trips
+        if (capability == Capability.TRIPS_REALTIME)
+            return false;
+        else
+            return super.hasCapability(capability);
+    }
+
+    @Override
     public QueryTripsResult queryTrips(final Location from, final @Nullable Location via, final Location to,
             final Date date, final boolean dep, final @Nullable TripOptions options) throws IOException {
         return queryTripsXml(from, via, to, date, dep, options);

--- a/enabler/src/de/schildbach/pte/NegentweeProvider.java
+++ b/enabler/src/de/schildbach/pte/NegentweeProvider.java
@@ -85,7 +85,9 @@ public class NegentweeProvider extends AbstractNetworkProvider {
             Capability.NEARBY_LOCATIONS,
             Capability.DEPARTURES,
             Capability.TRIPS,
-            Capability.TRIPS_VIA
+            Capability.TRIPS_VIA,
+            Capability.DEPARTURES_REALTIME,
+            Capability.TRIPS_REALTIME
     );
 
     private static final EnumSet<Product> trainProducts = EnumSet.of(Product.HIGH_SPEED_TRAIN, Product.REGIONAL_TRAIN,

--- a/enabler/src/de/schildbach/pte/NegentweeProvider.java
+++ b/enabler/src/de/schildbach/pte/NegentweeProvider.java
@@ -80,6 +80,14 @@ public class NegentweeProvider extends AbstractNetworkProvider {
     private static final TimeZone API_TIMEZONE = TimeZone.getTimeZone("Europe/Amsterdam");
     private static final int DEFAULT_MAX_LOCATIONS = 50;
 
+    private final List CAPABILITIES = Arrays.asList(
+            Capability.SUGGEST_LOCATIONS,
+            Capability.NEARBY_LOCATIONS,
+            Capability.DEPARTURES,
+            Capability.TRIPS,
+            Capability.TRIPS_VIA
+    );
+
     private static final EnumSet<Product> trainProducts = EnumSet.of(Product.HIGH_SPEED_TRAIN, Product.REGIONAL_TRAIN,
             Product.SUBURBAN_TRAIN);
 
@@ -696,15 +704,7 @@ public class NegentweeProvider extends AbstractNetworkProvider {
 
     @Override
     protected boolean hasCapability(Capability capability) {
-        switch (capability) {
-        case SUGGEST_LOCATIONS:
-        case NEARBY_LOCATIONS:
-        case DEPARTURES:
-        case TRIPS:
-            return true;
-        default:
-            return false;
-        }
+        return CAPABILITIES.contains(capability);
     }
 
     @Override

--- a/enabler/src/de/schildbach/pte/NetworkProvider.java
+++ b/enabler/src/de/schildbach/pte/NetworkProvider.java
@@ -49,7 +49,9 @@ public interface NetworkProvider {
         /* can query for departures */
         DEPARTURES,
         /* can query trips */
-        TRIPS
+        TRIPS,
+        /* supports trip queries passing by a specific location */
+        TRIPS_VIA
     }
 
     public enum Optimize {

--- a/enabler/src/de/schildbach/pte/NetworkProvider.java
+++ b/enabler/src/de/schildbach/pte/NetworkProvider.java
@@ -51,7 +51,11 @@ public interface NetworkProvider {
         /* can query trips */
         TRIPS,
         /* supports trip queries passing by a specific location */
-        TRIPS_VIA
+        TRIPS_VIA,
+        /* exposes real-time data on departures for delays and/or cancellations */
+        DEPARTURES_REALTIME,
+        /* exposes real-time data on trip queries for delays and/or cancellations */
+        TRIPS_REALTIME
     }
 
     public enum Optimize {

--- a/enabler/src/de/schildbach/pte/VrsProvider.java
+++ b/enabler/src/de/schildbach/pte/VrsProvider.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
@@ -80,6 +81,14 @@ import okhttp3.HttpUrl;
  * @author Michael Dyrna
  */
 public class VrsProvider extends AbstractNetworkProvider {
+
+    private final List CAPABILITIES = Arrays.asList(
+            Capability.SUGGEST_LOCATIONS,
+            Capability.NEARBY_LOCATIONS,
+            Capability.DEPARTURES,
+            Capability.TRIPS,
+            Capability.TRIPS_VIA
+    );
 
     private static final Logger log = LoggerFactory.getLogger(VrsProvider.class);
 
@@ -342,18 +351,7 @@ public class VrsProvider extends AbstractNetworkProvider {
 
     @Override
     protected boolean hasCapability(Capability capability) {
-        switch (capability) {
-        case DEPARTURES:
-            return true;
-        case NEARBY_LOCATIONS:
-            return true;
-        case SUGGEST_LOCATIONS:
-            return true;
-        case TRIPS:
-            return true;
-        default:
-            return false;
-        }
+        return CAPABILITIES.contains(capability);
     }
 
     // only stations supported

--- a/enabler/src/de/schildbach/pte/VrsProvider.java
+++ b/enabler/src/de/schildbach/pte/VrsProvider.java
@@ -87,7 +87,9 @@ public class VrsProvider extends AbstractNetworkProvider {
             Capability.NEARBY_LOCATIONS,
             Capability.DEPARTURES,
             Capability.TRIPS,
-            Capability.TRIPS_VIA
+            Capability.TRIPS_VIA,
+            Capability.DEPARTURES_REALTIME,
+            Capability.TRIPS_REALTIME
     );
 
     private static final Logger log = LoggerFactory.getLogger(VrsProvider.class);


### PR DESCRIPTION
This PR adds three new capabilities for network providers:
* `VIA` for providers that allow specifying a location to pass by
* `DEPARTURES_REALTIME` for providers that support real-time data on departures
* `TRIPS_REALTIME` for providers that support real-time data on trip queries.

As discussed in #95, the new capabilities are split into different commits.

Fixes #95.