### PR TITLE
Implement TripOptions for queryTrips method

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractHafasLegacyProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractHafasLegacyProvider.java
@@ -685,10 +685,8 @@ public abstract class AbstractHafasLegacyProvider extends AbstractHafasProvider 
 
     @Override
     public QueryTripsResult queryTrips(final Location from, final @Nullable Location via, final Location to,
-            final Date date, final boolean dep, final @Nullable Set<Product> products,
-            final @Nullable Optimize optimize, final @Nullable WalkSpeed walkSpeed,
-            final @Nullable Accessibility accessibility, final @Nullable Set<Option> options) throws IOException {
-        return queryTripsBinary(from, via, to, date, dep, products, walkSpeed, accessibility, options);
+            final Date date, final boolean dep, final @Nullable TripOptions options) throws IOException {
+        return queryTripsBinary(from, via, to, date, dep, options);
     }
 
     @Override
@@ -697,8 +695,7 @@ public abstract class AbstractHafasLegacyProvider extends AbstractHafasProvider 
     }
 
     protected final QueryTripsResult queryTripsXml(Location from, @Nullable Location via, Location to, final Date date,
-            final boolean dep, final @Nullable Set<Product> products, final @Nullable WalkSpeed walkSpeed,
-            final @Nullable Accessibility accessibility, final @Nullable Set<Option> options) throws IOException {
+            final boolean dep, @Nullable TripOptions options) throws IOException {
         final ResultHeader header = new ResultHeader(network, SERVER_PRODUCT);
 
         if (!from.isIdentified()) {
@@ -731,13 +728,16 @@ public abstract class AbstractHafasLegacyProvider extends AbstractHafasProvider 
         final Calendar c = new GregorianCalendar(timeZone);
         c.setTime(date);
 
+        if (options == null)
+            options = new TripOptions();
+
         final CharSequence productsStr;
-        if (products != null)
-            productsStr = productsString(products);
+        if (options.products != null)
+            productsStr = productsString(options.products);
         else
             productsStr = allProductsString();
 
-        final char bikeChar = (options != null && options.contains(Option.BIKE)) ? '1' : '0';
+        final char bikeChar = (options.options != null && options.options.contains(Option.BIKE)) ? '1' : '0';
 
         final StringBuilder conReq = new StringBuilder("<ConReq deliverPolyline=\"1\">");
         conReq.append("<Start>").append(locationXml(from));
@@ -764,7 +764,7 @@ public abstract class AbstractHafasLegacyProvider extends AbstractHafasProvider 
         // number of trips forwards
         conReq.append(" f=\"").append(numTripsRequested).append("\"");
         // percentual extension of change time
-        conReq.append(" chExtension=\"").append(walkSpeed == WalkSpeed.SLOW ? 50 : 0).append("\"");
+        conReq.append(" chExtension=\"").append(options.walkSpeed == WalkSpeed.SLOW ? 50 : 0).append("\"");
         // TODO nrChanges: max number of changes
         conReq.append(" sMode=\"N\"/>");
         conReq.append("</ConReq>");
@@ -1354,9 +1354,7 @@ public abstract class AbstractHafasLegacyProvider extends AbstractHafasProvider 
     private final static int QUERY_TRIPS_BINARY_BUFFER_SIZE = 384 * 1024;
 
     protected final QueryTripsResult queryTripsBinary(Location from, @Nullable Location via, Location to,
-            final Date date, final boolean dep, final @Nullable Set<Product> products,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            final @Nullable Set<Option> options) throws IOException {
+            final Date date, final boolean dep, @Nullable TripOptions options) throws IOException {
         final ResultHeader header = new ResultHeader(network, SERVER_PRODUCT);
 
         if (!from.isIdentified()) {
@@ -1386,8 +1384,11 @@ public abstract class AbstractHafasLegacyProvider extends AbstractHafasProvider 
             to = locations.get(0);
         }
 
+        if (options == null)
+            options = new TripOptions();
+
         final HttpUrl.Builder url = queryEndpoint.newBuilder().addPathSegment(apiLanguage);
-        appendQueryTripsBinaryParameters(url, from, via, to, date, dep, products, accessibility, options);
+        appendQueryTripsBinaryParameters(url, from, via, to, date, dep, options.products, options.accessibility, options.options);
         return queryTripsBinary(url.build(), from, via, to, QUERY_TRIPS_BINARY_BUFFER_SIZE);
     }
 

--- a/enabler/src/de/schildbach/pte/AbstractHafasMobileProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractHafasMobileProvider.java
@@ -144,10 +144,10 @@ public abstract class AbstractHafasMobileProvider extends AbstractHafasProvider 
 
     @Override
     public QueryTripsResult queryTrips(final Location from, final @Nullable Location via, final Location to,
-            final Date date, final boolean dep, final @Nullable Set<Product> products,
-            final @Nullable Optimize optimize, final @Nullable WalkSpeed walkSpeed,
-            final @Nullable Accessibility accessibility, final @Nullable Set<Option> options) throws IOException {
-        return jsonTripSearch(from, via, to, date, dep, products, null);
+            final Date date, final boolean dep, @Nullable TripOptions options) throws IOException {
+        if (options == null)
+            options = new TripOptions();
+        return jsonTripSearch(from, via, to, date, dep, options.products, null);
     }
 
     @Override

--- a/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
@@ -886,9 +886,7 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
 
     @Override
     public QueryTripsResult queryTrips(final Location from, final @Nullable Location via, final Location to,
-            final Date date, final boolean dep, final @Nullable Set<Product> products,
-            final @Nullable Optimize optimize, final @Nullable WalkSpeed walkSpeed,
-            final @Nullable Accessibility accessibility, final @Nullable Set<Option> options) throws IOException {
+            final Date date, final boolean dep, @Nullable TripOptions options) throws IOException {
         final ResultHeader resultHeader = new ResultHeader(network, SERVER_PRODUCT, SERVER_VERSION, null, 0, null);
 
         try {
@@ -901,10 +899,13 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
                 url.addQueryParameter("min_nb_journeys", Integer.toString(this.numTripsRequested));
                 url.addQueryParameter("depth", "0");
 
+                if (options == null)
+                    options = new TripOptions();
+
                 // Set walking speed.
-                if (walkSpeed != null) {
+                if (options.walkSpeed != null) {
                     final double walkingSpeed;
-                    switch (walkSpeed) {
+                    switch (options.walkSpeed) {
                     case SLOW:
                         walkingSpeed = 1.12 * 0.8;
                         break;
@@ -920,43 +921,43 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
                     url.addQueryParameter("walking_speed", Double.toString(walkingSpeed));
                 }
 
-                if (options != null && options.contains(Option.BIKE)) {
+                if (options.options != null && options.options.contains(Option.BIKE)) {
                     url.addQueryParameter("first_section_mode", "bike");
                     url.addQueryParameter("last_section_mode", "bike");
                 }
 
                 // Set forbidden physical modes.
-                if (products != null && !products.equals(Product.ALL)) {
+                if (options.products != null && !options.products.equals(Product.ALL)) {
                     url.addQueryParameter("forbidden_uris[]", "physical_mode:Air");
                     url.addQueryParameter("forbidden_uris[]", "physical_mode:Boat");
-                    if (!products.contains(Product.REGIONAL_TRAIN)) {
+                    if (!options.products.contains(Product.REGIONAL_TRAIN)) {
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Localdistancetrain");
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Train");
                     }
-                    if (!products.contains(Product.SUBURBAN_TRAIN)) {
+                    if (!options.products.contains(Product.SUBURBAN_TRAIN)) {
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Localtrain");
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Train");
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Rapidtransit");
                     }
-                    if (!products.contains(Product.SUBWAY)) {
+                    if (!options.products.contains(Product.SUBWAY)) {
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Metro");
                     }
-                    if (!products.contains(Product.TRAM)) {
+                    if (!options.products.contains(Product.TRAM)) {
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Tramway");
                     }
-                    if (!products.contains(Product.BUS)) {
+                    if (!options.products.contains(Product.BUS)) {
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Bus");
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Busrapidtransit");
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Coach");
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Shuttle");
                     }
-                    if (!products.contains(Product.FERRY)) {
+                    if (!options.products.contains(Product.FERRY)) {
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Ferry");
                     }
-                    if (!products.contains(Product.CABLECAR)) {
+                    if (!options.products.contains(Product.CABLECAR)) {
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Funicular");
                     }
-                    if (!products.contains(Product.ON_DEMAND)) {
+                    if (!options.products.contains(Product.ON_DEMAND)) {
                         url.addQueryParameter("forbidden_uris[]", "physical_mode:Taxi");
                     }
                 }
@@ -1024,8 +1025,7 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
                 }
 
                 if (newTo != null && newFrom != null)
-                    return queryTrips(newFrom, via, newTo, date, dep, products, optimize, walkSpeed, accessibility,
-                            options);
+                    return queryTrips(newFrom, via, newTo, date, dep, options);
 
                 if (ambiguousFrom != null || ambiguousTo != null)
                     return new QueryTripsResult(resultHeader, ambiguousFrom, null, ambiguousTo);

--- a/enabler/src/de/schildbach/pte/AbstractNetworkProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNetworkProvider.java
@@ -20,6 +20,7 @@ package de.schildbach.pte;
 import java.io.IOException;
 import java.net.Proxy;
 import java.nio.charset.Charset;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
@@ -32,9 +33,11 @@ import javax.annotation.Nullable;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 
+import de.schildbach.pte.dto.Location;
 import de.schildbach.pte.dto.Point;
 import de.schildbach.pte.dto.Position;
 import de.schildbach.pte.dto.Product;
+import de.schildbach.pte.dto.QueryTripsResult;
 import de.schildbach.pte.dto.Style;
 import de.schildbach.pte.util.HttpClient;
 
@@ -72,6 +75,14 @@ public abstract class AbstractNetworkProvider implements NetworkProvider {
     }
 
     protected abstract boolean hasCapability(Capability capability);
+
+    @Deprecated
+    @Override
+    public QueryTripsResult queryTrips(Location from, @Nullable Location via, Location to, Date date, boolean dep,
+            @Nullable Set<Product> products, @Nullable Optimize optimize, @Nullable WalkSpeed walkSpeed,
+            @Nullable Accessibility accessibility, @Nullable Set<Option> options) throws IOException {
+        return queryTrips(from, via, to, date, dep, new TripOptions(products, optimize, walkSpeed, accessibility, options));
+    }
 
     @Override
     public Set<Product> defaultProducts() {

--- a/enabler/src/de/schildbach/pte/AvvProvider.java
+++ b/enabler/src/de/schildbach/pte/AvvProvider.java
@@ -48,11 +48,8 @@ public class AvvProvider extends AbstractEfaProvider {
     @Override
     protected void appendXsltTripRequestParameters(final HttpUrl.Builder url, final Location from,
             final @Nullable Location via, final Location to, final Date time, final boolean dep,
-            final @Nullable Collection<Product> products, final @Nullable Optimize optimize,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            final @Nullable Set<Option> options) {
-        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, products, optimize, walkSpeed,
-                accessibility, options);
+            final @Nullable TripOptions options) {
+        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, options);
         url.addEncodedQueryParameter("inclMOT_11", "on"); // night bus
         url.addEncodedQueryParameter("inclMOT_13", "on");
         url.addEncodedQueryParameter("inclMOT_14", "on");

--- a/enabler/src/de/schildbach/pte/BayernProvider.java
+++ b/enabler/src/de/schildbach/pte/BayernProvider.java
@@ -138,13 +138,10 @@ public class BayernProvider extends AbstractEfaProvider {
     @Override
     protected void appendXsltTripRequestParameters(final HttpUrl.Builder url, final Location from,
             final @Nullable Location via, final Location to, final Date time, final boolean dep,
-            final @Nullable Collection<Product> products, final @Nullable Optimize optimize,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            final @Nullable Set<Option> options) {
-        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, products, optimize, walkSpeed,
-                accessibility, options);
-        if (products != null) {
-            for (final Product p : products) {
+            final @Nullable TripOptions options) {
+        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, options);
+        if (options != null && options.products != null) {
+            for (final Product p : options.products) {
                 if (p == Product.HIGH_SPEED_TRAIN)
                     url.addEncodedQueryParameter("inclMOT_15", "on").addEncodedQueryParameter("inclMOT_16", "on");
                 if (p == Product.REGIONAL_TRAIN)
@@ -158,10 +155,8 @@ public class BayernProvider extends AbstractEfaProvider {
 
     @Override
     public QueryTripsResult queryTrips(final Location from, final @Nullable Location via, final Location to,
-            final Date date, final boolean dep, final @Nullable Set<Product> products,
-            final @Nullable Optimize optimize, final @Nullable WalkSpeed walkSpeed,
-            final @Nullable Accessibility accessibility, final @Nullable Set<Option> options) throws IOException {
-        return queryTripsMobile(from, via, to, date, dep, products, optimize, walkSpeed, accessibility, options);
+            final Date date, final boolean dep, final @Nullable TripOptions options) throws IOException {
+        return queryTripsMobile(from, via, to, date, dep, options);
     }
 
     @Override

--- a/enabler/src/de/schildbach/pte/BsvagProvider.java
+++ b/enabler/src/de/schildbach/pte/BsvagProvider.java
@@ -51,11 +51,8 @@ public class BsvagProvider extends AbstractEfaProvider {
     @Override
     protected void appendXsltTripRequestParameters(final HttpUrl.Builder url, final Location from,
             final @Nullable Location via, final Location to, final Date time, final boolean dep,
-            final @Nullable Collection<Product> products, final @Nullable Optimize optimize,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            final @Nullable Set<Option> options) {
-        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, products, optimize, walkSpeed,
-                accessibility, options);
+            final @Nullable TripOptions options) {
+        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, options);
         url.addEncodedQueryParameter("inclMOT_11", "on");
     }
 

--- a/enabler/src/de/schildbach/pte/EireannProvider.java
+++ b/enabler/src/de/schildbach/pte/EireannProvider.java
@@ -50,10 +50,8 @@ public class EireannProvider extends AbstractHafasLegacyProvider {
 
     @Override
     public QueryTripsResult queryTrips(final Location from, final @Nullable Location via, final Location to,
-            final Date date, final boolean dep, final @Nullable Set<Product> products,
-            final @Nullable Optimize optimize, final @Nullable WalkSpeed walkSpeed,
-            final @Nullable Accessibility accessibility, final @Nullable Set<Option> options) throws IOException {
-        return queryTripsXml(from, via, to, date, dep, products, walkSpeed, accessibility, options);
+            final Date date, final boolean dep, final @Nullable TripOptions options) throws IOException {
+        return queryTripsXml(from, via, to, date, dep, options);
     }
 
     @Override

--- a/enabler/src/de/schildbach/pte/HslProvider.java
+++ b/enabler/src/de/schildbach/pte/HslProvider.java
@@ -435,8 +435,7 @@ public class HslProvider extends AbstractNetworkProvider {
     // NOTE: HSL ignores accessibility
     @Override
     public QueryTripsResult queryTrips(Location from, @Nullable Location via, Location to, Date date, boolean dep,
-            @Nullable Set<Product> products, @Nullable Optimize optimize, @Nullable WalkSpeed walkSpeed,
-            @Nullable Accessibility accessibility, @Nullable Set<Option> options) throws IOException {
+            @Nullable TripOptions options) throws IOException {
         final ResultHeader header = new ResultHeader(network, SERVER_PRODUCT);
 
         if (!from.isIdentified()) {
@@ -475,22 +474,25 @@ public class HslProvider extends AbstractNetworkProvider {
 
         url.addQueryParameter("timetype", dep ? "departure" : "arrival");
 
-        if (walkSpeed != WalkSpeed.NORMAL)
-            url.addQueryParameter("walk_speed", Integer.toString(walkSpeed == WalkSpeed.SLOW ? 30 : 100));
+        if (options == null)
+            options = new TripOptions();
+
+        if (options.walkSpeed != WalkSpeed.NORMAL)
+            url.addQueryParameter("walk_speed", Integer.toString(options.walkSpeed == WalkSpeed.SLOW ? 30 : 100));
         url.addQueryParameter("show", "5");
 
-        if (products != null && products.size() > 0) {
+        if (options.products != null && options.products.size() > 0) {
             List<String> tt = new ArrayList<>();
-            if (products.contains(Product.HIGH_SPEED_TRAIN) || products.contains(Product.REGIONAL_TRAIN)
-                    || products.contains(Product.SUBURBAN_TRAIN))
+            if (options.products.contains(Product.HIGH_SPEED_TRAIN) || options.products.contains(Product.REGIONAL_TRAIN)
+                    || options.products.contains(Product.SUBURBAN_TRAIN))
                 tt.add("train");
-            if (products.contains(Product.SUBWAY))
+            if (options.products.contains(Product.SUBWAY))
                 tt.add("metro");
-            if (products.contains(Product.TRAM))
+            if (options.products.contains(Product.TRAM))
                 tt.add("tram");
-            if (products.contains(Product.BUS))
+            if (options.products.contains(Product.BUS))
                 tt.add("bus");
-            if (products.contains(Product.FERRY))
+            if (options.products.contains(Product.FERRY))
                 tt.add("ferry");
 
             if (tt.size() > 0)

--- a/enabler/src/de/schildbach/pte/InvgProvider.java
+++ b/enabler/src/de/schildbach/pte/InvgProvider.java
@@ -274,10 +274,8 @@ public class InvgProvider extends AbstractHafasLegacyProvider {
 
     @Override
     public QueryTripsResult queryTrips(final Location from, final @Nullable Location via, final Location to,
-            final Date date, final boolean dep, final @Nullable Set<Product> products,
-            final @Nullable Optimize optimize, final @Nullable WalkSpeed walkSpeed,
-            final @Nullable Accessibility accessibility, final @Nullable Set<Option> options) throws IOException {
-        return queryTripsXml(from, via, to, date, dep, products, walkSpeed, accessibility, options);
+            final Date date, final boolean dep, final @Nullable TripOptions options) throws IOException {
+        return queryTripsXml(from, via, to, date, dep, options);
     }
 
     @Override

--- a/enabler/src/de/schildbach/pte/NegentweeProvider.java
+++ b/enabler/src/de/schildbach/pte/NegentweeProvider.java
@@ -816,8 +816,7 @@ public class NegentweeProvider extends AbstractNetworkProvider {
 
     @Override
     public QueryTripsResult queryTrips(Location from, @Nullable Location via, Location to, Date date, boolean dep,
-            @Nullable Set<Product> products, @Nullable Optimize optimize, @Nullable WalkSpeed walkSpeed,
-            @Nullable Accessibility accessibility, @Nullable Set<Option> options) throws IOException {
+            @Nullable TripOptions options) throws IOException {
         if (!from.hasId())
             return ambiguousQueryTrips(from, via, to);
 
@@ -838,13 +837,17 @@ public class NegentweeProvider extends AbstractNetworkProvider {
             queryParameters.add(new QueryParameter("via", via.id));
         }
 
-        if (walkSpeed != null && walkSpeed == WalkSpeed.SLOW) {
+        if (options == null)
+            options = new TripOptions();
+
+        if (options.walkSpeed != null && options.walkSpeed == WalkSpeed.SLOW) {
             queryParameters.add(new QueryParameter("interchangeTime", InterchangeTime.EXTRA.toString()));
         } else {
             queryParameters.add(new QueryParameter("interchangeTime", InterchangeTime.STANDARD.toString()));
         }
 
         // Add trip product options to query
+        Set<Product> products = options.products;
         if (products == null || products.size() == 0) {
             products = defaultProducts();
         }

--- a/enabler/src/de/schildbach/pte/NetworkProvider.java
+++ b/enabler/src/de/schildbach/pte/NetworkProvider.java
@@ -68,6 +68,43 @@ public interface NetworkProvider {
         BIKE
     }
 
+    public class TripOptions {
+        public final @Nullable Set<Product> products;
+        public final @Nullable Optimize optimize;
+        public final @Nullable WalkSpeed walkSpeed;
+        public final @Nullable Accessibility accessibility;
+        public final @Nullable Set<Option> options;
+
+        /**
+         * @param products
+         *            products to take into account, or {@code null} for the provider default
+         * @param optimize
+         *            optimize trip for one aspect, e.g. duration
+         * @param walkSpeed
+         *            walking ability, or {@code null} for the provider default
+         * @param accessibility
+         *            route accessibility, or {@code null} for the provider default
+         * @param options
+         *            additional options, or {@code null} for the provider default
+         */
+        public TripOptions(@Nullable Set<Product> products, @Nullable Optimize optimize, @Nullable WalkSpeed walkSpeed,
+                           @Nullable Accessibility accessibility, @Nullable Set<Option> options) {
+            this.products = products;
+            this.optimize = optimize;
+            this.walkSpeed = walkSpeed;
+            this.accessibility = accessibility;
+            this.options = options;
+        }
+
+        public TripOptions() {
+            this.products = null;
+            this.optimize = null;
+            this.walkSpeed = null;
+            this.accessibility = null;
+            this.options = null;
+        }
+    }
+
     NetworkId id();
 
     boolean hasCapabilities(final Capability... capabilities);
@@ -137,20 +174,16 @@ public interface NetworkProvider {
      *            desired date for departing, mandatory
      * @param dep
      *            date is departure date? {@code true} for departure, {@code false} for arrival
-     * @param products
-     *            products to take into account, or {@code null} for the provider default
-     * @param optimize
-     *            optimize trip for one aspect, e.g. duration
-     * @param walkSpeed
-     *            walking ability, or {@code null} for the provider default
-     * @param accessibility
-     *            route accessibility, or {@code null} for the provider default
      * @param options
-     *            additional options, or {@code null} for the provider default
+     *            additional trip options such as products, optimize, walkSpeed and accessibility, or {@code null} for the provider default
      * @return result object that can contain alternatives to clear up ambiguousnesses, or contains possible
      *         trips
      * @throws IOException
      */
+    QueryTripsResult queryTrips(Location from, @Nullable Location via, Location to, Date date, boolean dep,
+            @Nullable TripOptions options) throws IOException;
+
+    @Deprecated
     QueryTripsResult queryTrips(Location from, @Nullable Location via, Location to, Date date, boolean dep,
             @Nullable Set<Product> products, @Nullable Optimize optimize, @Nullable WalkSpeed walkSpeed,
             @Nullable Accessibility accessibility, @Nullable Set<Option> options) throws IOException;

--- a/enabler/src/de/schildbach/pte/NvbwProvider.java
+++ b/enabler/src/de/schildbach/pte/NvbwProvider.java
@@ -98,10 +98,8 @@ public class NvbwProvider extends AbstractEfaProvider {
 
     @Override
     public QueryTripsResult queryTrips(final Location from, final @Nullable Location via, final Location to,
-            final Date date, final boolean dep, final @Nullable Set<Product> products,
-            final @Nullable Optimize optimize, final @Nullable WalkSpeed walkSpeed,
-            final @Nullable Accessibility accessibility, final @Nullable Set<Option> options) throws IOException {
-        return queryTripsMobile(from, via, to, date, dep, products, optimize, walkSpeed, accessibility, options);
+            final Date date, final boolean dep, final @Nullable TripOptions options) throws IOException {
+        return queryTripsMobile(from, via, to, date, dep, options);
     }
 
     @Override

--- a/enabler/src/de/schildbach/pte/StvProvider.java
+++ b/enabler/src/de/schildbach/pte/StvProvider.java
@@ -78,10 +78,8 @@ public class StvProvider extends AbstractEfaProvider {
 
     @Override
     public QueryTripsResult queryTrips(final Location from, final @Nullable Location via, final Location to,
-            final Date date, final boolean dep, final @Nullable Set<Product> products,
-            final @Nullable Optimize optimize, final @Nullable WalkSpeed walkSpeed,
-            final @Nullable Accessibility accessibility, final @Nullable Set<Option> options) throws IOException {
-        return queryTripsMobile(from, via, to, date, dep, products, optimize, walkSpeed, accessibility, options);
+            final Date date, final boolean dep, final @Nullable TripOptions options) throws IOException {
+        return queryTripsMobile(from, via, to, date, dep, options);
     }
 
     @Override

--- a/enabler/src/de/schildbach/pte/SydneyProvider.java
+++ b/enabler/src/de/schildbach/pte/SydneyProvider.java
@@ -51,13 +51,10 @@ public class SydneyProvider extends AbstractEfaProvider {
     @Override
     protected void appendXsltTripRequestParameters(final HttpUrl.Builder url, final Location from,
             final @Nullable Location via, final Location to, final Date time, final boolean dep,
-            final @Nullable Collection<Product> products, final @Nullable Optimize optimize,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            final @Nullable Set<Option> options) {
-        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, products, optimize, walkSpeed,
-                accessibility, options);
-        if (products != null) {
-            for (final Product p : products) {
+            final @Nullable TripOptions options) {
+        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, options);
+        if (options != null && options.products != null) {
+            for (final Product p : options.products) {
                 if (p == Product.BUS)
                     url.addEncodedQueryParameter("inclMOT_11", "on"); // school bus
             }

--- a/enabler/src/de/schildbach/pte/VgnProvider.java
+++ b/enabler/src/de/schildbach/pte/VgnProvider.java
@@ -72,11 +72,8 @@ public class VgnProvider extends AbstractEfaProvider {
     @Override
     protected void appendXsltTripRequestParameters(final HttpUrl.Builder url, final Location from,
             final @Nullable Location via, final Location to, final Date date, final boolean dep,
-            final @Nullable Collection<Product> products, final @Nullable Optimize optimize,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            final @Nullable Set<Option> options) {
-        super.appendXsltTripRequestParameters(url, from, via, to, date, dep, products, optimize, walkSpeed,
-                accessibility, options);
+            final @Nullable TripOptions options) {
+        super.appendXsltTripRequestParameters(url, from, via, to, date, dep, options);
         url.addEncodedQueryParameter("itdLPxx_showTariffLevel", "1");
     }
 }

--- a/enabler/src/de/schildbach/pte/VmsProvider.java
+++ b/enabler/src/de/schildbach/pte/VmsProvider.java
@@ -44,11 +44,8 @@ public class VmsProvider extends AbstractEfaProvider {
     @Override
     protected void appendXsltTripRequestParameters(final HttpUrl.Builder url, final Location from,
             final @Nullable Location via, final Location to, final Date time, final boolean dep,
-            final @Nullable Collection<Product> products, final @Nullable Optimize optimize,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            final @Nullable Set<Option> options) {
-        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, products, optimize, walkSpeed,
-                accessibility, options);
+            final @Nullable TripOptions options) {
+        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, options);
         url.addEncodedQueryParameter("inclMOT_11", "on");
         url.addEncodedQueryParameter("inclMOT_13", "on");
         url.addEncodedQueryParameter("inclMOT_14", "on");

--- a/enabler/src/de/schildbach/pte/VmvProvider.java
+++ b/enabler/src/de/schildbach/pte/VmvProvider.java
@@ -45,11 +45,8 @@ public class VmvProvider extends AbstractEfaProvider {
     @Override
     protected void appendXsltTripRequestParameters(final HttpUrl.Builder url, final Location from,
             final @Nullable Location via, final Location to, final Date time, final boolean dep,
-            final @Nullable Collection<Product> products, final @Nullable Optimize optimize,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            final @Nullable Set<Option> options) {
-        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, products, optimize, walkSpeed,
-                accessibility, options);
+            final @Nullable TripOptions options) {
+        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, options);
         url.addEncodedQueryParameter("inclMOT_11", "on");
     }
 }

--- a/enabler/src/de/schildbach/pte/VrrProvider.java
+++ b/enabler/src/de/schildbach/pte/VrrProvider.java
@@ -61,13 +61,10 @@ public class VrrProvider extends AbstractEfaProvider {
     @Override
     protected void appendXsltTripRequestParameters(final HttpUrl.Builder url, final Location from,
             final @Nullable Location via, final Location to, final Date time, final boolean dep,
-            final @Nullable Collection<Product> products, final @Nullable Optimize optimize,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            final @Nullable Set<Option> options) {
-        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, products, optimize, walkSpeed,
-                accessibility, options);
-        if (products != null) {
-            for (final Product p : products) {
+            final @Nullable TripOptions options) {
+        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, options);
+        if (options != null && options.products != null) {
+            for (final Product p : options.products) {
                 if (p == Product.CABLECAR)
                     url.addEncodedQueryParameter("inclMOT_11", "on"); // Schwebebahn
             }

--- a/enabler/src/de/schildbach/pte/VrsProvider.java
+++ b/enabler/src/de/schildbach/pte/VrsProvider.java
@@ -655,9 +655,7 @@ public class VrsProvider extends AbstractNetworkProvider {
     // options not supported.
     @Override
     public QueryTripsResult queryTrips(final Location from, final @Nullable Location via, final Location to, Date date,
-            boolean dep, final @Nullable Set<Product> products, final @Nullable Optimize optimize,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            @Nullable Set<Option> options) throws IOException {
+            boolean dep, @Nullable TripOptions options) throws IOException {
         // The EXACT_POINTS feature generates an about 50% bigger API response, probably well compressible.
         final boolean EXACT_POINTS = true;
         final List<Location> ambiguousFrom = new ArrayList<>();
@@ -688,6 +686,9 @@ public class VrsProvider extends AbstractNetworkProvider {
                     QueryTripsResult.Status.UNKNOWN_TO);
         }
 
+        if (options == null)
+            options = new TripOptions();
+
         final HttpUrl.Builder url = API_BASE.newBuilder();
         url.addQueryParameter("eID", "tx_vrsinfo_ass2_router");
         url.addQueryParameter("f", fromString);
@@ -697,8 +698,8 @@ public class VrsProvider extends AbstractNetworkProvider {
         }
         url.addQueryParameter(dep ? "d" : "a", formatDate(date));
         url.addQueryParameter("s", "t");
-        if (products != null && !products.equals(Product.ALL))
-            url.addQueryParameter("p", generateProducts(products));
+        if (options.products != null && !options.products.equals(Product.ALL))
+            url.addQueryParameter("p", generateProducts(options.products));
         url.addQueryParameter("o", "v" + (EXACT_POINTS ? "p" : ""));
 
         final CharSequence page = httpClient.get(url.build());
@@ -895,7 +896,7 @@ public class VrsProvider extends AbstractNetworkProvider {
             context.from = from;
             context.to = to;
             context.via = via;
-            context.products = products;
+            context.products = options.products;
             if (trips.size() == 1) {
                 if (dep)
                     context.disableLater();

--- a/enabler/src/de/schildbach/pte/WienProvider.java
+++ b/enabler/src/de/schildbach/pte/WienProvider.java
@@ -50,13 +50,10 @@ public class WienProvider extends AbstractEfaProvider {
     @Override
     protected void appendXsltTripRequestParameters(final HttpUrl.Builder url, final Location from,
             final @Nullable Location via, final Location to, final Date time, final boolean dep,
-            final @Nullable Collection<Product> products, final @Nullable Optimize optimize,
-            final @Nullable WalkSpeed walkSpeed, final @Nullable Accessibility accessibility,
-            final @Nullable Set<Option> options) {
-        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, products, optimize, walkSpeed,
-                accessibility, options);
-        if (products != null) {
-            for (final Product p : products) {
+            final @Nullable TripOptions options) {
+        super.appendXsltTripRequestParameters(url, from, via, to, time, dep, options);
+        if (options != null && options.products != null) {
+            for (final Product p : options.products) {
                 if (p == Product.BUS)
                     url.addEncodedQueryParameter("inclMOT_11", "on"); // night bus
             }


### PR DESCRIPTION
This PR moves the following "auxiliary" parameters from `queryTrips` into a separate `TripOptions` class while leaving `from`, `via`, `to`, `date` and `dep` as normal parameters: `products`, `optimize`, `walkSpeed`, `accessibility` and `options`.
See also the quick discussion in #214.

For this, I've added a new method signature in the `NetworkProvider` interface while marking the old one as _deprecated_. I've also changed the implementations in all the subclasses to use the new parameters and implemented the old method signature in `AbstractNetworkProvider` as a simple alias for the new one.

I have run all the live tests to make sure the PR does not break any providers. There were exactly the same amount of failures before and after the changes, but I was not able to test providers requiring secret keys except the Navitia based ones.

Fixes #214.