### PR TITLE
Fix javadoc for queryMoreTrips

### DIFF
--- a/enabler/src/de/schildbach/pte/NetworkProvider.java
+++ b/enabler/src/de/schildbach/pte/NetworkProvider.java
@@ -160,8 +160,8 @@ public interface NetworkProvider {
      * 
      * @param context
      *            context to query more trips from
-     * @param next
-     *            {@code true} for get next trips, {@code false} for get previous trips
+     * @param later
+     *            {@code true} to get later trips, {@code false} to get earlier trips
      * @return result object that contains possible trips
      * @throws IOException
      */


### PR DESCRIPTION
Just a little fix in the javadoc of this method. See #216 