### PR TITLE
Add Massachusetts, USA provider

### DIFF
--- a/enabler/src/de/schildbach/pte/MassachusettsProvider.java
+++ b/enabler/src/de/schildbach/pte/MassachusettsProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Erik Uhlmann.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte;
+
+import okhttp3.HttpUrl;
+
+/**
+ * @author Erik Uhlmann
+ */
+public class MassachusettsProvider extends AbstractNavitiaProvider {
+	private static final String API_REGION = "us-ma";
+
+	public MassachusettsProvider(HttpUrl apiBase, String authorization) {
+		super(NetworkId.MASSACHUSETTS, apiBase, authorization);
+		setTimeZone("America/New_York");
+	}
+
+	public MassachusettsProvider(final String authorization) {
+		super(NetworkId.MASSACHUSETTS, authorization);
+		setTimeZone("America/New_York");
+	}
+
+	@Override
+	protected String region() {
+		return API_REGION;
+	}
+}

--- a/enabler/src/de/schildbach/pte/NetworkId.java
+++ b/enabler/src/de/schildbach/pte/NetworkId.java
@@ -76,7 +76,7 @@ public enum NetworkId {
     DUB,
 
     // United States
-    RTACHICAGO, OREGON,
+    RTACHICAGO, OREGON, MASSACHUSETTS,
 
     // Canada
     ONTARIO, QUEBEC, BRITISHCOLUMBIA,

--- a/enabler/test/de/schildbach/pte/live/MassachusettsProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/MassachusettsProviderLiveTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Erik Uhlmann.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte.live;
+
+import org.junit.Test;
+
+import de.schildbach.pte.MassachusettsProvider;
+
+/**
+ * @author Erik Uhlmann
+ */
+public class MassachusettsProviderLiveTest extends AbstractNavitiaProviderLiveTest {
+	public MassachusettsProviderLiveTest() {
+		super(new MassachusettsProvider(secretProperty("navitia.authorization")));
+	}
+
+	@Test
+	public void nearbyStations() throws Exception {
+		nearbyStationsStation("stop_point:OUB:SP:70243");
+	}
+
+	@Test
+	public void nearbyStationsByCoordinate() throws Exception {
+		nearbyStationsAny(42353187, -71067045);
+	}
+
+	@Test
+	public void queryDepartures() throws Exception {
+		queryDeparturesEquivsFalse("stop_point:OUB:SP:70198");
+	}
+
+	@Test
+	public void queryDeparturesInvalidStation() throws Exception {
+		queryDeparturesInvalidStation("stop_point:OUB:SP:xxxx");
+	}
+
+	@Test
+	public void suggestLocations() throws Exception {
+		suggestLocationsFromName("Airport");
+	}
+}


### PR DESCRIPTION
This adds support for the Navitia `us-ma` region, which has 25 Massachusetts transport networks including MBTA (Boston), PVTA (western mass.), and Massport.

~~I plan to test this in Transportr soon, but have not done so yet.~~ The live test functions as expected (using MBTA stops).

Update: Tested in Transportr. It seems to be functional (at least for MBTA), but routes are displayed as straight lines between points instead of following the actual path of the public transportation. I'm not sure if this means I didn't configure something correctly in Transportr or if Navitia doesn't have path information available for the MBTA.