### PR TITLE
Negentwee: use the correct type parameter name

### DIFF
--- a/enabler/src/de/schildbach/pte/NegentweeProvider.java
+++ b/enabler/src/de/schildbach/pte/NegentweeProvider.java
@@ -212,7 +212,7 @@ public class NegentweeProvider extends AbstractNetworkProvider {
         // Add types if specified
         String locationTypes = locationTypesToQueryParameterString(types);
         if (locationTypes.length() > 0)
-            queryParameters.add(new QueryParameter("types", locationTypes));
+            queryParameters.add(new QueryParameter("type", locationTypes));
 
         HttpUrl url = buildApiUrl("locations", queryParameters);
         final CharSequence page = httpClient.get(url);
@@ -724,7 +724,7 @@ public class NegentweeProvider extends AbstractNetworkProvider {
         // Add types if specified
         String locationTypes = locationTypesToQueryParameterString(types);
         if (locationTypes.length() > 0)
-            queryParameters.add(new QueryParameter("types", locationTypes));
+            queryParameters.add(new QueryParameter("type", locationTypes));
 
         HttpUrl url = buildApiUrl("locations", queryParameters);
 

--- a/enabler/test/de/schildbach/pte/live/NegentweeProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/NegentweeProviderLiveTest.java
@@ -49,6 +49,13 @@ public class NegentweeProviderLiveTest extends AbstractProviderLiveTest {
                 new Location(LocationType.STATION, "station-amsterdam-centraal"));
         print(result);
         assertEquals(NearbyLocationsResult.Status.OK, result.status);
+
+        // Assert that queryNearbyStations only returns STATION locations
+        assertTrue(result.locations != null);
+        assertTrue(result.locations.size() > 0);
+        for (Location location : result.locations) {
+            assertEquals(location.type, LocationType.STATION);
+        }
     }
 
     @Test


### PR DESCRIPTION
Previous fix accidentally changed the query parameter name, causing it to be ignored.

This changes it back and tests the parameter.