### PR TITLE
AVV Aachen Styles and ALT/IC fixes

### DIFF
--- a/enabler/src/de/schildbach/pte/AvvAachenProvider.java
+++ b/enabler/src/de/schildbach/pte/AvvAachenProvider.java
@@ -20,7 +20,7 @@ package de.schildbach.pte;
 import java.util.regex.Matcher;
 
 import de.schildbach.pte.dto.Product;
-
+import de.schildbach.pte.dto.Style;
 import okhttp3.HttpUrl;
 
 /**
@@ -32,10 +32,14 @@ public class AvvAachenProvider extends AbstractHafasClientInterfaceProvider {
             Product.HIGH_SPEED_TRAIN, Product.BUS, Product.SUBURBAN_TRAIN, Product.SUBWAY, Product.TRAM, Product.BUS,
             Product.BUS, Product.ON_DEMAND, Product.FERRY };
 
+    protected static final Map<String, Style> STYLES = new HashMap<>();
+
+
     public AvvAachenProvider(final String jsonApiAuthorization) {
         super(NetworkId.AVV_AACHEN, API_BASE, PRODUCTS_MAP);
         setApiVersion("1.16");
-        setApiClient("{\"id\":\"AVV_AACHEN\",\"type\":\"AND\"}");
+	    setStyles(STYLES);
+	    setApiClient("{\"id\":\"AVV_AACHEN\",\"type\":\"AND\"}");
         setApiAuthorization(jsonApiAuthorization);
     }
 
@@ -62,4 +66,112 @@ public class AvvAachenProvider extends AbstractHafasClientInterfaceProvider {
             return new String[] { m.group(1), m.group(2) };
         return super.splitStationName(address);
     }
+
+
+    static {
+        STYLES.put("BSEV", new Style(Style.parseColor("#ED028C"), Style.GRAY, Style.WHITE, 0));
+
+        // braun
+        STYLES.put("B3", new Style(Style.parseColor("#CF9C46"), Style.WHITE));
+        STYLES.put("B3A", new Style(Style.parseColor("#CF9C46"), Style.WHITE));
+        STYLES.put("B3B", new Style(Style.parseColor("#CF9C46"), Style.WHITE));
+        STYLES.put("B13", new Style(Style.parseColor("#CF9C46"), Style.WHITE));
+        STYLES.put("B13A", new Style(Style.parseColor("#CF9C46"), Style.WHITE));
+        STYLES.put("B13B", new Style(Style.parseColor("#CF9C46"), Style.WHITE));
+
+        // rot
+        STYLES.put("B4", new Style(Style.RED, Style.WHITE));
+        STYLES.put("B16", new Style(Style.RED, Style.WHITE));
+
+        // pink
+        STYLES.put("B1", new Style(Style.parseColor("#ED028C"), Style.WHITE));
+        STYLES.put("B11", new Style(Style.parseColor("#ED028C"), Style.WHITE));
+        STYLES.put("B21", new Style(Style.parseColor("#ED028C"), Style.WHITE));
+        STYLES.put("B41", new Style(Style.parseColor("#ED028C"), Style.WHITE));
+        STYLES.put("B51", new Style(Style.parseColor("#ED028C"), Style.WHITE));
+
+        // rosa
+        STYLES.put("B33", new Style(Style.parseColor("#F499C2"), Style.WHITE));
+        STYLES.put("B34", new Style(Style.parseColor("#F499C2"), Style.WHITE));
+        STYLES.put("B54", new Style(Style.parseColor("#F499C2"), Style.WHITE));
+        STYLES.put("B73", new Style(Style.parseColor("#F499C2"), Style.WHITE));
+
+        // blau grau
+        STYLES.put("B5", new Style(Style.parseColor("#6F92AE"), Style.WHITE));
+        STYLES.put("B45", new Style(Style.parseColor("#6F92AE"), Style.WHITE));
+
+        // blau
+        STYLES.put("B15", new Style(Style.parseColor("#00AEEF"), Style.WHITE));
+        STYLES.put("B25", new Style(Style.parseColor("#00AEEF"), Style.WHITE));
+        STYLES.put("B35", new Style(Style.parseColor("#00AEEF"), Style.WHITE));
+        STYLES.put("B43", new Style(Style.parseColor("#00AEEF"), Style.WHITE));
+        STYLES.put("B55", new Style(Style.parseColor("#00AEEF"), Style.WHITE));
+        STYLES.put("B65", new Style(Style.parseColor("#00AEEF"), Style.WHITE));
+
+        // hellblau
+        STYLES.put("B63", new Style(Style.parseColor("#6BCFF6"), Style.WHITE));
+        STYLES.put("B66", new Style(Style.parseColor("#6BCFF6"), Style.WHITE));
+
+        // lila
+        STYLES.put("B7", new Style(Style.parseColor("#802990"), Style.WHITE));
+        STYLES.put("B17", new Style(Style.parseColor("#802990"), Style.WHITE));
+        STYLES.put("B27", new Style(Style.parseColor("#802990"), Style.WHITE));
+        STYLES.put("B37", new Style(Style.parseColor("#802990"), Style.WHITE));
+        STYLES.put("B47", new Style(Style.parseColor("#802990"), Style.WHITE));
+
+        // braun?
+        STYLES.put("B14", new Style(Style.parseColor("#B96730"), Style.WHITE));
+        STYLES.put("B24", new Style(Style.parseColor("#B96730"), Style.WHITE));
+        STYLES.put("B74", new Style(Style.parseColor("#802990"), Style.WHITE));
+
+        // orange
+        STYLES.put("BAL1", new Style(Style.parseColor("#F7931D"), Style.WHITE));
+        STYLES.put("44", new Style(Style.parseColor("#F7931D"), Style.WHITE));
+        STYLES.put("67", new Style(Style.parseColor("#F7931D"), Style.WHITE));
+
+        // navy
+        STYLES.put("Wü 1", new Style(Style.parseColor("#303A74"), Style.WHITE));
+
+        // grün, hellgrün und noch ein grün
+        STYLES.put("B31", new Style(Style.parseColor("#9FD05F"), Style.WHITE));
+        STYLES.put("B36", new Style(Style.parseColor("#9FD05F"), Style.WHITE));
+
+        STYLES.put("B53", new Style(Style.parseColor("#00B59D"), Style.WHITE));
+
+        STYLES.put("B50", new Style(Style.parseColor("#00A54F"), Style.WHITE));
+        STYLES.put("B70", new Style(Style.parseColor("#00A54F"), Style.WHITE));
+        STYLES.put("B80", new Style(Style.parseColor("#00A54F"), Style.WHITE));
+
+        // gelb
+        STYLES.put("B2", new Style(Style.YELLOW, Style.WHITE));
+        STYLES.put("B12", new Style(Style.YELLOW, Style.WHITE));
+        STYLES.put("B22", new Style(Style.YELLOW, Style.WHITE));
+        STYLES.put("B23", new Style(Style.YELLOW, Style.WHITE));
+
+        // schnellbusse
+        STYLES.put("B103", new Style(Style.Shape.ROUNDED, Style.parseColor("#CF9C46"), Style.WHITE, Style.parseColor("#444444")));
+
+        STYLES.put("B125", new Style(Style.Shape.ROUNDED, Style.parseColor("#00AEEF"), Style.WHITE, Style.parseColor("#444444")));
+        STYLES.put("B135", new Style(Style.Shape.ROUNDED, Style.parseColor("#00AEEF"), Style.WHITE, Style.parseColor("#444444")));
+        STYLES.put("B147", new Style(Style.Shape.ROUNDED, Style.parseColor("#802990"), Style.WHITE, Style.parseColor("#444444")));
+
+        STYLES.put("B151", new Style(Style.Shape.ROUNDED, Style.parseColor("#ED028C"), Style.WHITE, Style.parseColor("#444444")));
+
+        STYLES.put("B173", new Style(Style.Shape.ROUNDED, Style.parseColor("#F499C2"), Style.WHITE, Style.parseColor("#444444")));
+
+        STYLES.put("B220", new Style(Style.Shape.ROUNDED, Style.parseColor("#ED028C"), Style.WHITE, Style.parseColor("#444444")));
+        STYLES.put("BSB20", new Style(Style.Shape.ROUNDED, Style.parseColor("#ED028C"), Style.WHITE, Style.parseColor("#444444")));
+
+        STYLES.put("BSB63", new Style(Style.Shape.ROUNDED, Style.parseColor("#6BCFF6"), Style.WHITE, Style.parseColor("#444444")));
+        STYLES.put("BSB66", new Style(Style.Shape.ROUNDED, Style.parseColor("#6BCFF6"), Style.WHITE, Style.parseColor("#444444")));
+
+//        // regionalexpress
+//        STYLES.put("RRE1", new Style(Style.Shape.RECT, Style.parseColor("#F44336"), Style.WHITE));
+//        STYLES.put("RRE4", new Style(Style.Shape.RECT, Style.parseColor("#F7931D"), Style.WHITE));
+//        STYLES.put("RRE9", new Style(Style.Shape.RECT, Style.parseColor("#802990"), Style.WHITE));
+//        // euregiobahn blau
+//        STYLES.put("RRB20", new Style(Style.Shape.RECT, Style.parseColor("#2196F3"), Style.WHITE));
+
+    }
+
 }

--- a/enabler/src/de/schildbach/pte/AvvAachenProvider.java
+++ b/enabler/src/de/schildbach/pte/AvvAachenProvider.java
@@ -17,11 +17,13 @@
 
 package de.schildbach.pte;
 
+import com.sun.istack.internal.Nullable;
+
+import java.util.Map;
 import java.util.regex.Matcher;
 
 import de.schildbach.pte.dto.Line;
 import de.schildbach.pte.dto.Product;
-
 import de.schildbach.pte.dto.Style;
 import okhttp3.HttpUrl;
 
@@ -69,8 +71,9 @@ public class AvvAachenProvider extends AbstractHafasClientInterfaceProvider {
         return super.splitStationName(address);
     }
 
-	@Override
-	protected Line newLine(String operator, Product product, String name) {
+    @Override
+    protected Line newLine(final String operator, final Product product, final @Nullable String name,
+                           final @Nullable String shortName, final @Nullable String number) {
 		final String normalizedName;
 		if (product == Product.ON_DEMAND && name.startsWith("ALT")) { // bsp. ALT74ALT -> 74ALT
 			normalizedName = name.substring(3);
@@ -80,7 +83,7 @@ public class AvvAachenProvider extends AbstractHafasClientInterfaceProvider {
 			return new Line(null, operator, Product.HIGH_SPEED_TRAIN, name, lineStyle(operator, Product.HIGH_SPEED_TRAIN, name));
 		}
 
-		return super.newLine(operator, product, name);
+		return super.newLine(operator, product, name, shortName, number);
 	}
 
 

--- a/enabler/src/de/schildbach/pte/AvvAachenProvider.java
+++ b/enabler/src/de/schildbach/pte/AvvAachenProvider.java
@@ -17,10 +17,11 @@
 
 package de.schildbach.pte;
 
-import com.sun.istack.internal.Nullable;
-
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
+
+import javax.annotation.Nullable;
 
 import de.schildbach.pte.dto.Line;
 import de.schildbach.pte.dto.Product;

--- a/enabler/src/de/schildbach/pte/AvvAachenProvider.java
+++ b/enabler/src/de/schildbach/pte/AvvAachenProvider.java
@@ -19,7 +19,9 @@ package de.schildbach.pte;
 
 import java.util.regex.Matcher;
 
+import de.schildbach.pte.dto.Line;
 import de.schildbach.pte.dto.Product;
+
 import de.schildbach.pte.dto.Style;
 import okhttp3.HttpUrl;
 
@@ -66,6 +68,20 @@ public class AvvAachenProvider extends AbstractHafasClientInterfaceProvider {
             return new String[] { m.group(1), m.group(2) };
         return super.splitStationName(address);
     }
+
+	@Override
+	protected Line newLine(String operator, Product product, String name) {
+		final String normalizedName;
+		if (product == Product.ON_DEMAND && name.startsWith("ALT")) { // bsp. ALT74ALT -> 74ALT
+			normalizedName = name.substring(3);
+			return new Line(null, operator, product, normalizedName, lineStyle(operator, product, normalizedName));
+
+		} else if (product == Product.REGIONAL_TRAIN && name.startsWith("IC")) { // AVV hat belgische und niederländische ICs als Regionalbahn drin
+			return new Line(null, operator, Product.HIGH_SPEED_TRAIN, name, lineStyle(operator, Product.HIGH_SPEED_TRAIN, name));
+		}
+
+		return super.newLine(operator, product, name);
+	}
 
 
     static {


### PR DESCRIPTION
There are different line colors in usage. 
I took the colors from [this map](https://www.aseag.de/fileadmin/user_upload/documents/Netzplaene/Netzplan_Stadtgebiet_Aachen2017_18.pdf), which I think is the most used in Aachen. 

The RE-Trains 1, 4, 9 and RB20 also have a distinct color, but i've excluded it. Probably it's too confusing

Another commit adds some parsing improvements:
`ALT47ALT -> 74ALT`  and IC trains of netherlands and belgium where listed as regional trains.