### PR TITLE
VgsProvider: Add Salt and enable Mic-Mac

### DIFF
--- a/enabler/src/de/schildbach/pte/VgsProvider.java
+++ b/enabler/src/de/schildbach/pte/VgsProvider.java
@@ -19,6 +19,8 @@ package de.schildbach.pte;
 
 import java.util.regex.Matcher;
 
+import com.google.common.base.Charsets;
+
 import de.schildbach.pte.dto.Product;
 
 import okhttp3.HttpUrl;
@@ -37,6 +39,7 @@ public class VgsProvider extends AbstractHafasClientInterfaceProvider {
         setApiVersion("1.21");
         setApiClient("{\"id\":\"ZPS-SAAR\",\"type\":\"AND\"}");
         setApiAuthorization(jsonApiAuthorization);
+        setRequestMicMacSalt("HJtlubisvxiJxss".getBytes(Charsets.UTF_8));
     }
 
     @Override


### PR DESCRIPTION
For the new saarfahrplan.de endpoint to work, it requires the mic-mac parameters to be send. This PR adds the salt found by @juliuste and @derhuerst from their [hafas-client](/public-transport/hafas-client/blob/master/p/saarfahrplan/index.js#L39).