### PR TITLE
Fix live tests for departures with equivs

### DIFF
--- a/enabler/test/de/schildbach/pte/live/AbstractProviderLiveTest.java
+++ b/enabler/test/de/schildbach/pte/live/AbstractProviderLiveTest.java
@@ -106,7 +106,7 @@ public abstract class AbstractProviderLiveTest {
 
         if (result.status == QueryDeparturesResult.Status.OK) {
             if (equivs)
-                assertTrue(result.stationDepartures.size() > 1);
+                assertTrue(result.stationDepartures.size() >= 1);
             else
                 assertTrue(result.stationDepartures.size() == 1);
         }


### PR DESCRIPTION
The live tests fail for cases where equivalent stations can be queried for departures too, but only one station is actually returned. The live test should accept having `result.stationDepartures.size() == 1` for these cases.