### PR TITLE
Fix AbstractNavitiaProvider to use UTC times

### DIFF
--- a/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
+++ b/enabler/src/de/schildbach/pte/AbstractNavitiaProvider.java
@@ -20,6 +20,7 @@ package de.schildbach.pte;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
+import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -317,11 +318,15 @@ public abstract class AbstractNavitiaProvider extends AbstractNetworkProvider {
     }
 
     private Date parseDate(final String dateString) throws ParseException {
-        return new SimpleDateFormat("yyyyMMdd'T'HHmmss").parse(dateString);
+        DateFormat format = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
+        format.setTimeZone(timeZone);
+        return format.parse(dateString);
     }
 
     private String printDate(final Date date) {
-        return new SimpleDateFormat("yyyyMMdd'T'HHmmss").format(date);
+        DateFormat format = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
+        format.setTimeZone(timeZone);
+        return format.format(date);
     }
 
     private LinkedList<Point> parsePath(final JSONArray coordinates) throws IOException {


### PR DESCRIPTION
This PR fixes current problems when sending a request to Navitia from within another timezone as the provider has. Until now, the date and time is sent to Navitia as if local and provider's timezone were equal. By setting `DateFormat.timeZone` to the provider's one while converting time to string in both directions, it now works as expected.

So `AbstractNavitiaProvider` now is in line with the expected behavior stated by @schildbach in grote/Transportr#577:

> the API is UTC time for both request and response


Fixes #260.