### PR TITLE
Select provider for pte service from configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project contains several subprojects:
  * [__enabler__](enabler):
      The library itself. This is probably what you're searching for. See the subproject's [README](enabler/README.md) for more information.
  * [__service__](service):
-     An example of how the library could be used as a web service. It's still very incomplete though.
+     An example of how the library could be used as a web service. It's still incomplete though. If you want to test it, see the subproject's [README](service/README.md) for more information.
 
 You can build all sub-projects at once using Gradle:
 

--- a/service/.gitignore
+++ b/service/.gitignore
@@ -2,3 +2,4 @@
 /.project
 /.settings/
 /bin/
+config.json

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,11 @@
+Public Transport Enabler Service
+================================
+
+This is a web service API providing the functionality of the Public Transport Enabler Java library to get data from public transport providers.
+
+Using providers that require secrets
+------------------------------------
+
+Copy the example configuration file, open it and define the provider to use:
+
+    $ cp service/example.config.json service/config.json

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile project(':enabler')
     compile 'org.springframework:spring-webmvc:3.1.0.RELEASE'
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.4'
+    compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1'
 }
 
 compileJava {

--- a/service/example.config.json
+++ b/service/example.config.json
@@ -1,0 +1,4 @@
+{  
+    "provider": "Spain",
+    "token": "YOUR_ACCESS_TOKEN"
+}

--- a/service/src/main/java/de/schildbach/pte/service/Application.java
+++ b/service/src/main/java/de/schildbach/pte/service/Application.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.pte.service;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import de.schildbach.pte.AbstractNetworkProvider;
+
+/**
+ * @author Felix Delattre
+ */
+public class Application {
+
+    public static AbstractNetworkProvider get_provider() {
+
+        /* Read configuration about provider and additional information related from config.json */
+        String provider = "", token = "";
+        JSONParser parser = new JSONParser();
+        try (Reader reader = new FileReader("service/config.json")) {
+            JSONObject jsonObject = (JSONObject) parser.parse(reader);
+            provider = (String) jsonObject.get("provider");
+            token = (String) jsonObject.get("token");
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+
+        /* Create Provider object from dynamic class name obtained from configuration above */
+        Object object = null;
+        try {
+            Class<?> classDefinition = Class.forName("de.schildbach.pte." + provider + "Provider");
+
+            if (token != "") {
+                Constructor<?> classConstructor = classDefinition.getConstructor(String.class);
+                object = classConstructor.newInstance(new Object[] { token });
+            }
+            else {
+                object = classDefinition.newInstance();
+            }
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+        catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+        catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
+    
+        return (AbstractNetworkProvider) object;
+    }
+}
+

--- a/service/src/main/java/de/schildbach/pte/service/LocationController.java
+++ b/service/src/main/java/de/schildbach/pte/service/LocationController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import de.schildbach.pte.RtProvider;
+import de.schildbach.pte.AbstractNetworkProvider;
 import de.schildbach.pte.dto.Location;
 import de.schildbach.pte.dto.LocationType;
 import de.schildbach.pte.dto.NearbyLocationsResult;
@@ -34,10 +34,11 @@ import de.schildbach.pte.dto.SuggestLocationsResult;
 
 /**
  * @author Andreas Schildbach
+ * @author Felix Delattre
  */
 @Controller
 public class LocationController {
-    private final RtProvider provider = new RtProvider();
+    private final AbstractNetworkProvider provider = Application.get_provider();
 
     @RequestMapping(value = "/location/suggest", method = RequestMethod.GET)
     @ResponseBody

--- a/service/src/main/java/de/schildbach/pte/service/TripController.java
+++ b/service/src/main/java/de/schildbach/pte/service/TripController.java
@@ -26,17 +26,18 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import de.schildbach.pte.RtProvider;
+import de.schildbach.pte.AbstractNetworkProvider;
 import de.schildbach.pte.dto.Location;
 import de.schildbach.pte.dto.LocationType;
 import de.schildbach.pte.dto.QueryTripsResult;
 
 /**
  * @author Andreas Schildbach
+ * @author Felix Delattre
  */
 @Controller
 public class TripController {
-    private final RtProvider provider = new RtProvider();
+    private final AbstractNetworkProvider provider = Application.get_provider();
 
     @RequestMapping(value = "/trip", method = RequestMethod.GET)
     @ResponseBody


### PR DESCRIPTION
This PR introduces a `config.json` file, which must be similar to the `example.config.json` file. It defines the  service's provider (and a token if required, or can be omitted).

Not sure whether this is the best/desired approach. Perhaps it would be better to handle the authorization tokens similar and together with the `secrets.properties`!? But shouldn't live this more globally then? And do we want to include the provider selector in this file, in order to get rid of the json file? @schildbach, some guidance would be really nice.
