### PR TITLE
Train categories for Polish HAFAS modified to reflect reality

### DIFF
--- a/src/de/schildbach/pte/PlProvider.java
+++ b/src/de/schildbach/pte/PlProvider.java
@@ -33,7 +33,7 @@ public class PlProvider extends AbstractHafasLegacyProvider {
     private static final HttpUrl API_BASE = HttpUrl.parse("http://mobil.rozklad-pkp.pl/bin/");
     private static final Product[] PRODUCTS_MAP = { Product.HIGH_SPEED_TRAIN, // High speed trains from other countries
 			Product.HIGH_SPEED_TRAIN, // EIP, EIC, EC and international equivalents
-            Product.HIGH_SPEED_TRAIN, // IC, TLK, IR and international equivalents
+			Product.HIGH_SPEED_TRAIN, // IC, TLK, IR and international equivalents
 			Product.REGIONAL_TRAIN, // R (Regio), Os (Osobowy) and other regional and suburban trains
 			Product.BUS, Product.BUS, Product.FERRY };
 

--- a/src/de/schildbach/pte/PlProvider.java
+++ b/src/de/schildbach/pte/PlProvider.java
@@ -31,8 +31,11 @@ import okhttp3.HttpUrl;
  */
 public class PlProvider extends AbstractHafasLegacyProvider {
     private static final HttpUrl API_BASE = HttpUrl.parse("http://mobil.rozklad-pkp.pl/bin/");
-    private static final Product[] PRODUCTS_MAP = { Product.HIGH_SPEED_TRAIN, Product.HIGH_SPEED_TRAIN,
-            Product.REGIONAL_TRAIN, Product.SUBURBAN_TRAIN, Product.BUS, Product.BUS, Product.FERRY };
+    private static final Product[] PRODUCTS_MAP = { Product.HIGH_SPEED_TRAIN, // High speed trains from other countries
+			Product.HIGH_SPEED_TRAIN, // EIP, EIC, EC and international equivalents
+            Product.HIGH_SPEED_TRAIN, // IC, TLK, IR and international equivalents
+			Product.REGIONAL_TRAIN, // R (Regio), Os (Osobowy) and other regional and suburban trains
+			Product.BUS, Product.BUS, Product.FERRY };
 
     public PlProvider() {
         super(NetworkId.PL, API_BASE, "pn", PRODUCTS_MAP);
@@ -73,6 +76,13 @@ public class PlProvider extends AbstractHafasLegacyProvider {
     @Override
     protected Product normalizeType(final String type) {
         final String ucType = type.toUpperCase();
+
+		if ("SKM".equals(ucType)) // SKM Trojmiasto in Gdansk Metropolitan Area
+			return Product.SUBURBAN_TRAIN;
+		if ("SKW".equals(ucType)) // SKM Warszawa
+			return Product.SUBURBAN_TRAIN;
+		if ("WKD".equals(ucType)) // Warsaw Commuter Railway (Warszawa Kolej Dojazdowa)
+			return Product.SUBURBAN_TRAIN;	
 
         if ("AR".equals(ucType)) // Arriva Polaczen
             return Product.REGIONAL_TRAIN;


### PR DESCRIPTION
While using Transportr app for rail travel I realized that train categories for Polish rail companies are not correctly assigned. The high speed product category (which as far as I see includes all long-distance trains in other networks, like the German) was assigned only to high speed rail from other countries (like TGV or ICE) and for EIP, EIC and EC trains. It was not assigned to IC and TLK trains (as well as other trains like Rychlik in Czechia, which can also be checked using Polish version of HAFAS), which are long-distance trains operated and treated mostly like the upper categories (the fares are different and these trains stops on a bit more stations, so they are like IC or D trains in Germany). They, however, are assigned to Regional Train category. Regional trains (and Osobowy and other equivalent categories, like Regiobahn and Trillex in Germany) on the other hand were assigned to Suburban category, as well as SKMs (Polish equivalent to S-Bahn). 

This should fix the problem, IC/TLK trains were assigned to the highest category, Regio and equivalents were assigned to the Regional Train category and SKM trains, due to the fact that they are assigned to the same category as regional in the Polish version of HAFAS were manually assigned to the Suburban Train category.

Also, it might be a good idea to create an additional Product category – long-distance train, between regional and high speed trains for all the connections that are not TGV, ICE, AV etc. but are still long-distance (like IC, R, TLK etc.).