### PR TITLE
Negentwee: Use full trip fares instead of per leg

### DIFF
--- a/src/de/schildbach/pte/NegentweeProvider.java
+++ b/src/de/schildbach/pte/NegentweeProvider.java
@@ -485,15 +485,17 @@ public class NegentweeProvider extends AbstractNetworkProvider {
 
         // Get journey fares
         JSONObject fareInfo = trip.getJSONObject("fareInfo");
-        JSONArray fareLegs = fareInfo.getJSONArray("legs");
 
-        Fare[] foundFares = new Fare[fareLegs.length()];
-        for (int i = 0; i < fareLegs.length(); i++) {
-            foundFares[i] = fareFromJSONObject(fareLegs.getJSONObject(i));
+        List<Fare> tripFares = null;
+        if (fareInfo.getBoolean("complete")) {
+            tripFares = Arrays.asList(
+                new Fare("Full-price", Fare.Type.ADULT, Currency.getInstance("EUR"),
+                    fareInfo.getInt("fullPriceCents") / 100, null, null),
+                new Fare("Reduced-price", Fare.Type.ADULT, Currency.getInstance("EUR"),
+                    fareInfo.getInt("reducedPriceCents") / 100, null, null));
         }
 
-        return new Trip(trip.getString("id"), from, to, foundLegs, Arrays.asList(foundFares), null,
-                trip.getInt("numberOfChanges"));
+        return new Trip(trip.getString("id"), from, to, foundLegs, tripFares, null, trip.getInt("numberOfChanges"));
     }
 
     private Stop stopFromJSONObject(JSONObject stop) throws JSONException {


### PR DESCRIPTION
The current implementation adds the individual fares for each leg to the Trip object. Looking at the other providers, this is not correct, and there is no way to express individual leg fares. Transportr also assumes the fares are for the full trip, so it displays the wrong price.

I removed the per leg fares for now and only add the full-price and the reduced-price fares for the whole trip if available (there is no way to express the difference between the two with the current fare types, other than the name string).