### PR TITLE
MVV München: cleanup temp lines

### DIFF
--- a/src/de/schildbach/pte/MvvProvider.java
+++ b/src/de/schildbach/pte/MvvProvider.java
@@ -110,8 +110,6 @@ public class MvvProvider extends AbstractEfaProvider {
         STYLES.put("SS6", new Style(Shape.CIRCLE, Style.parseColor("#00975f"), Style.WHITE));
         STYLES.put("SS7", new Style(Shape.CIRCLE, Style.parseColor("#943126"), Style.WHITE));
         STYLES.put("SS8", new Style(Shape.CIRCLE, Style.BLACK, Style.parseColor("#ffcc00")));
-        STYLES.put("SS18",
-                new Style(Shape.CIRCLE, Style.parseColor("#16bae7"), Style.parseColor("#f0aa00"), Style.WHITE, 0));
         STYLES.put("SS20", new Style(Shape.CIRCLE, Style.parseColor("#ea516d"), Style.WHITE));
 
         STYLES.put("T12", new Style(Shape.RECT, Style.parseColor("#96368b"), Style.WHITE));
@@ -128,10 +126,9 @@ public class MvvProvider extends AbstractEfaProvider {
         STYLES.put("T27", new Style(Shape.RECT, Style.parseColor("#f7a600"), Style.WHITE));
         STYLES.put("T28", new Style(Shape.RECT, Style.WHITE, Style.parseColor("#f7a600"), Style.parseColor("#f7a600")));
         STYLES.put("T29", new Style(Shape.RECT, Style.WHITE, Style.parseColor("#e30613"), Style.parseColor("#e30613")));
-        STYLES.put("T31",
-                new Style(Shape.RECT, Style.parseColor("#e30613"), Style.parseColor("#bc7a00"), Style.WHITE, 0));
-        STYLES.put("T38",
-                new Style(Shape.RECT, Style.parseColor("#1fa22e"), Style.parseColor("#23bae2"), Style.WHITE, 0));
+        STYLES.put("T31", new Style(Shape.RECT, Style.parseColor("#bc7a00"), Style.WHITE));
+        STYLES.put("T36",
+                new Style(Shape.RECT, Style.parseColor("#0065ae"), Style.parseColor("#8b563e"), Style.WHITE, 0));
         STYLES.put("TN17", new Style(Shape.RECT, Style.parseColor("#999999"), Style.parseColor("#ffff00")));
         STYLES.put("TN19", new Style(Shape.RECT, Style.parseColor("#999999"), Style.parseColor("#ffff00")));
         STYLES.put("TN20", new Style(Shape.RECT, Style.parseColor("#999999"), Style.parseColor("#ffff00")));


### PR DESCRIPTION
remove defunct S18, T38
add T36 (in service till Nov 2020)
set correct color scheme for T31