### PR TITLE
VMS: update API base URL

### DIFF
--- a/src/de/schildbach/pte/VmsProvider.java
+++ b/src/de/schildbach/pte/VmsProvider.java
@@ -34,7 +34,7 @@ import okhttp3.HttpUrl;
  * @author Andreas Schildbach
  */
 public class VmsProvider extends AbstractEfaProvider {
-    private static final HttpUrl API_BASE = HttpUrl.parse("https://www.vms.de/vms2/");
+    private static final HttpUrl API_BASE = HttpUrl.parse("https://www.vms.de/Oeffi/");
 
     public VmsProvider() {
         this(API_BASE);


### PR DESCRIPTION
should fix #311 
The old API URL seems to have gone