### PR TITLE
Updated KVV line colours

### DIFF
--- a/src/de/schildbach/pte/KvvProvider.java
+++ b/src/de/schildbach/pte/KvvProvider.java
@@ -65,31 +65,35 @@ public class KvvProvider extends AbstractEfaProvider {
     private static final Map<String, Style> STYLES = new HashMap<>();
 
     static {
-        // S-Bahn
+        // Stadtbahn AVG
         STYLES.put("SS1", new Style(Style.parseColor("#00a76c"), Style.WHITE));
         STYLES.put("SS11", new Style(Style.parseColor("#00a76c"), Style.WHITE));
-        STYLES.put("SS2", new Style(Style.parseColor("#9f68ab"), Style.WHITE));
-        STYLES.put("SS3", new Style(Style.parseColor("#00a99d"), Style.BLACK));
+        STYLES.put("SS12", new Style(Style.parseColor("#00a76c"), Style.WHITE));
+        STYLES.put("SS2", new Style(Style.parseColor("#b286bc"), Style.WHITE));
         STYLES.put("SS31", new Style(Style.parseColor("#00a99d"), Style.WHITE));
         STYLES.put("SS32", new Style(Style.parseColor("#00a99d"), Style.WHITE));
-        STYLES.put("SS33", new Style(Style.parseColor("#00a99d"), Style.WHITE));
         STYLES.put("SS4", new Style(Style.parseColor("#9f184c"), Style.WHITE));
-        STYLES.put("SS41", new Style(Style.parseColor("#9f184c"), Style.WHITE));
+        STYLES.put("SS41", new Style(Style.parseColor("#bed730"), Style.WHITE));
+        STYLES.put("SS42", new Style(Style.parseColor("#0097bb"), Style.WHITE));
         STYLES.put("SS5", new Style(Style.parseColor("#f69795"), Style.BLACK));
         STYLES.put("SS51", new Style(Style.parseColor("#f69795"), Style.BLACK));
         STYLES.put("SS52", new Style(Style.parseColor("#f69795"), Style.BLACK));
-        STYLES.put("SS6", new Style(Style.parseColor("#292369"), Style.WHITE));
-        STYLES.put("SS7", new Style(Style.parseColor("#fef200"), Style.BLACK));
-        STYLES.put("SS71", new Style(Style.parseColor("#fef200"), Style.BLACK));
-        STYLES.put("SS8", new Style(Style.parseColor("#6e6928"), Style.WHITE));
-        STYLES.put("SS81", new Style(Style.parseColor("#6e6928"), Style.WHITE));
-        STYLES.put("SS9", new Style(Style.parseColor("#fab499"), Style.BLACK));
+        STYLES.put("SS6", new Style(Style.parseColor("#282268"), Style.WHITE));
+        STYLES.put("SS7", new Style(Style.parseColor("#fff200"), Style.BLACK));
+        STYLES.put("SS71", new Style(Style.parseColor("#fff200"), Style.BLACK));
+        STYLES.put("SS8", new Style(Style.parseColor("#6e692a"), Style.WHITE));
+        STYLES.put("SS81", new Style(Style.parseColor("#6e692a"), Style.WHITE));
 
-        // S-Bahn RheinNeckar
+        // S-Bahn Rhein-Neckar
+        STYLES.put("ddb|SS1", new Style(Style.parseColor("#e11a22"), Style.WHITE));
+        STYLES.put("ddb|SS2", new Style(Style.parseColor("#0077c0"), Style.WHITE));
         STYLES.put("ddb|SS3", new Style(Style.parseColor("#ffdd00"), Style.BLACK));
         STYLES.put("ddb|SS33", new Style(Style.parseColor("#8d5ca6"), Style.WHITE));
         STYLES.put("ddb|SS4", new Style(Style.parseColor("#00a650"), Style.WHITE));
-        STYLES.put("ddb|SS5", new Style(Style.parseColor("#f89835"), Style.WHITE));
+        STYLES.put("ddb|SS44", new Style(Style.parseColor("#00a650"), Style.WHITE));
+        STYLES.put("ddb|SS5", new Style(Style.parseColor("#f79433"), Style.WHITE));
+        STYLES.put("ddb|SS51", new Style(Style.parseColor("#f79433"), Style.WHITE));
+        STYLES.put("ddb|SS9", new Style(Style.parseColor("#a6ce42"), Style.WHITE));
 
         // Tram
         STYLES.put("T1", new Style(Shape.RECT, Style.parseColor("#ed1c24"), Style.WHITE));
@@ -102,54 +106,69 @@ public class KvvProvider extends AbstractEfaProvider {
         STYLES.put("T4E", new Style(Shape.RECT, Style.parseColor("#ffcb04"), Style.BLACK));
         STYLES.put("T5", new Style(Shape.RECT, Style.parseColor("#00c0f3"), Style.WHITE));
         STYLES.put("T5E", new Style(Shape.RECT, Style.parseColor("#00c0f3"), Style.WHITE));
-        STYLES.put("T6", new Style(Shape.RECT, Style.parseColor("#80c342"), Style.WHITE));
-        STYLES.put("T6E", new Style(Shape.RECT, Style.parseColor("#80c342"), Style.WHITE));
-        STYLES.put("T7", new Style(Shape.RECT, Style.parseColor("#58595b"), Style.WHITE));
-        STYLES.put("T7E", new Style(Shape.RECT, Style.parseColor("#58595b"), Style.WHITE));
+        STYLES.put("T6", new Style(Shape.RECT, Style.parseColor("#80c342"), Style.WHITE)); // Baustellenlinie
+        STYLES.put("T6E", new Style(Shape.RECT, Style.parseColor("#80c342"), Style.WHITE)); // Baustellenlinie
+        STYLES.put("T7", new Style(Shape.RECT, Style.parseColor("#58595b"), Style.WHITE)); // Baustellenlinie
+        STYLES.put("T7E", new Style(Shape.RECT, Style.parseColor("#58595b"), Style.WHITE)); // Baustellenlinie
         STYLES.put("T8", new Style(Shape.RECT, Style.parseColor("#f7931d"), Style.BLACK));
         STYLES.put("T8E", new Style(Shape.RECT, Style.parseColor("#f7931d"), Style.BLACK));
+        STYLES.put("T10", new Style(Shape.RECT, Style.parseColor("#a4d7bb"), Style.BLACK)); // Baustellenlinie
+        STYLES.put("T10E", new Style(Shape.RECT, Style.parseColor("#a4d7bb"), Style.BLACK)); // Baustellenlinie
 
-        // Bus - only used on bus plan
-        // LINES.put("B21", new Style(Shape.CIRCLE, Style.parseColor("#2e3092"), Style.WHITE));
-        // LINES.put("B22", new Style(Shape.CIRCLE, Style.parseColor("#00aeef"), Style.WHITE));
-        // LINES.put("B23", new Style(Shape.CIRCLE, Style.parseColor("#56c5d0"), Style.WHITE));
-        // LINES.put("B24", new Style(Shape.CIRCLE, Style.parseColor("#a1d1e6"), Style.WHITE));
-        // LINES.put("B26", new Style(Shape.CIRCLE, Style.parseColor("#2e3092"), Style.WHITE));
-        // LINES.put("B27", new Style(Shape.CIRCLE, Style.parseColor("#00aeef"), Style.WHITE));
-        // LINES.put("B30", new Style(Shape.CIRCLE, Style.parseColor("#adbc72"), Style.WHITE));
-        // LINES.put("B31", new Style(Shape.CIRCLE, Style.parseColor("#62bb46"), Style.WHITE));
-        // LINES.put("B32", new Style(Shape.CIRCLE, Style.parseColor("#177752"), Style.WHITE));
-        // LINES.put("B42", new Style(Shape.CIRCLE, Style.parseColor("#177752"), Style.WHITE));
-        // LINES.put("B44", new Style(Shape.CIRCLE, Style.parseColor("#62bb46"), Style.WHITE));
-        // LINES.put("B47", new Style(Shape.CIRCLE, Style.parseColor("#adbc72"), Style.WHITE));
-        // LINES.put("B50", new Style(Shape.CIRCLE, Style.parseColor("#a25641"), Style.WHITE));
-        // LINES.put("B51", new Style(Shape.CIRCLE, Style.parseColor("#d2ab67"), Style.WHITE));
-        // LINES.put("B52", new Style(Shape.CIRCLE, Style.parseColor("#a25641"), Style.WHITE));
-        // LINES.put("B55", new Style(Shape.CIRCLE, Style.parseColor("#806a50"), Style.WHITE));
-        // LINES.put("B60", new Style(Shape.CIRCLE, Style.parseColor("#806a50"), Style.WHITE));
-        // LINES.put("B62", new Style(Shape.CIRCLE, Style.parseColor("#d2ab67"), Style.WHITE));
-        // LINES.put("B70", new Style(Shape.CIRCLE, Style.parseColor("#574187"), Style.WHITE));
-        // LINES.put("B71", new Style(Shape.CIRCLE, Style.parseColor("#874487"), Style.WHITE));
-        // LINES.put("B72", new Style(Shape.CIRCLE, Style.parseColor("#9b95c9"), Style.WHITE));
-        // LINES.put("B73", new Style(Shape.CIRCLE, Style.parseColor("#574187"), Style.WHITE));
-        // LINES.put("B74", new Style(Shape.CIRCLE, Style.parseColor("#9b95c9"), Style.WHITE));
-        // LINES.put("B75", new Style(Shape.CIRCLE, Style.parseColor("#874487"), Style.WHITE));
-        // LINES.put("B107", new Style(Shape.CIRCLE, Style.parseColor("#9d9fa1"), Style.WHITE));
-        // LINES.put("B118", new Style(Shape.CIRCLE, Style.parseColor("#9d9fa1"), Style.WHITE));
-        // LINES.put("B123", new Style(Shape.CIRCLE, Style.parseColor("#9d9fa1"), Style.WHITE));
+        // Stadtbus Karlsruhe
+        STYLES.put("B21", new Style(Shape.CIRCLE, Style.parseColor("#177752"), Style.WHITE));
+        STYLES.put("B22", new Style(Shape.CIRCLE, Style.parseColor("#62bb46"), Style.WHITE));
+        STYLES.put("B22A", new Style(Shape.CIRCLE, Style.parseColor("62bb46"), Style.WHITE));
+        STYLES.put("B22B", new Style(Shape.CIRCLE, Style.parseColor("#62bb46"), Style.WHITE));
+        STYLES.put("B23", new Style(Shape.CIRCLE, Style.parseColor("#adbc72"), Style.WHITE));
+        STYLES.put("B24", new Style(Shape.CIRCLE, Style.parseColor("#004a21"), Style.WHITE));
+        STYLES.put("B26", new Style(Shape.CIRCLE, Style.parseColor("#d7df23"), Style.WHITE));
+        STYLES.put("B27", new Style(Shape.CIRCLE, Style.parseColor("#00a851"), Style.WHITE));
+        STYLES.put("B27E", new Style(Shape.CIRCLE, Style.parseColor("#00a851"), Style.WHITE));
+        STYLES.put("B29", new Style(Shape.CIRCLE, Style.parseColor("#90ab98"), Style.WHITE));
+        STYLES.put("B30", new Style(Shape.CIRCLE, Style.parseColor("#00aeef"), Style.WHITE));
+        STYLES.put("B31", new Style(Shape.CIRCLE, Style.parseColor("#a1d1e6"), Style.WHITE));
+        STYLES.put("BALT31", new Style(Shape.CIRCLE, Style.parseColor("#231f20"), Style.YELLOW)); // Anruf-Linien-Taxi
+        STYLES.put("B31X", new Style(Shape.CIRCLE, Style.parseColor("#a1d1e6"), Style.WHITE));
+        STYLES.put("BALT31X", new Style(Shape.CIRCLE, Style.parseColor("#231f20"), Style.YELLOW)); // Anruf-Linien-Taxi
+        STYLES.put("B32", new Style(Shape.CIRCLE, Style.parseColor("#485e88"), Style.WHITE));
+        STYLES.put("BALT32", new Style(Shape.CIRCLE, Style.parseColor("#231f20"), Style.YELLOW)); // Anruf-Linien-Taxi
+        STYLES.put("B42", new Style(Shape.CIRCLE, Style.parseColor("#485e88"), Style.WHITE));
+        STYLES.put("BALT42", new Style(Shape.CIRCLE, Style.parseColor("#231f20"), Style.YELLOW)); // Anruf-Linien-Taxi
+        STYLES.put("B44", new Style(Shape.CIRCLE, Style.parseColor("#a1d1e6"), Style.WHITE));
+        STYLES.put("B44X", new Style(Shape.CIRCLE, Style.parseColor("#a1d1e6"), Style.WHITE));
+        STYLES.put("B47", new Style(Shape.CIRCLE, Style.parseColor("#00aeef"), Style.WHITE));
+        STYLES.put("B47A", new Style(Shape.CIRCLE, Style.parseColor("#00aeef"), Style.WHITE));
+        STYLES.put("B47X", new Style(Shape.CIRCLE, Style.parseColor("#00aeef"), Style.WHITE));
+        STYLES.put("B50", new Style(Shape.CIRCLE, Style.parseColor("#874487"), Style.WHITE));
+        STYLES.put("B51", new Style(Shape.CIRCLE, Style.parseColor("#b592b9"), Style.WHITE));
+        STYLES.put("B52", new Style(Shape.CIRCLE, Style.parseColor("#874487"), Style.WHITE));
+        STYLES.put("BALT53", new Style(Shape.CIRCLE, Style.parseColor("#231f20"), Style.YELLOW)); // Anruf-Linien-Taxi
+        STYLES.put("BALT54", new Style(Shape.CIRCLE, Style.parseColor("#231f20"), Style.YELLOW)); // Anruf-Linien-Taxi
+        STYLES.put("B55", new Style(Shape.CIRCLE, Style.parseColor("#574187"), Style.WHITE));
+        STYLES.put("B60", new Style(Shape.CIRCLE, Style.parseColor("#574187"), Style.WHITE));
+        STYLES.put("B62", new Style(Shape.CIRCLE, Style.parseColor("#9b95c9"), Style.WHITE));
+        STYLES.put("BALT64", new Style(Shape.CIRCLE, Style.parseColor("#231f20"), Style.YELLOW)); // Anruf-Linien-Taxi
+        STYLES.put("B70", new Style(Shape.CIRCLE, Style.parseColor("#806a50"), Style.WHITE));
+        STYLES.put("B71", new Style(Shape.CIRCLE, Style.parseColor("#b2a291"), Style.WHITE));
+        STYLES.put("B72", new Style(Shape.CIRCLE, Style.parseColor("#d2ab67"), Style.WHITE));
+        STYLES.put("B73", new Style(Shape.CIRCLE, Style.parseColor("#806a50"), Style.WHITE));
+        STYLES.put("B74", new Style(Shape.CIRCLE, Style.parseColor("#d2ab67"), Style.WHITE));
+        STYLES.put("B75", new Style(Shape.CIRCLE, Style.parseColor("#a25641"), Style.WHITE));
+        STYLES.put("B83", new Style(Shape.CIRCLE, Style.parseColor("#808285"), Style.WHITE));
 
         // Nightliner
-        STYLES.put("BNL3", new Style(Style.parseColor("#947139"), Style.WHITE));
-        STYLES.put("BNL4", new Style(Style.parseColor("#ffcb04"), Style.BLACK));
-        STYLES.put("BNL5", new Style(Style.parseColor("#00c0f3"), Style.WHITE));
-        STYLES.put("BNL6", new Style(Style.parseColor("#80c342"), Style.WHITE));
-
-        // Anruf-Linien-Taxi
-        STYLES.put("BALT6", new Style(Shape.RECT, Style.BLACK, Style.YELLOW));
-        STYLES.put("BALT11", new Style(Shape.RECT, Style.BLACK, Style.YELLOW));
-        STYLES.put("BALT12", new Style(Shape.RECT, Style.BLACK, Style.YELLOW));
-        STYLES.put("BALT13", new Style(Shape.RECT, Style.BLACK, Style.YELLOW));
-        STYLES.put("BALT14", new Style(Shape.RECT, Style.BLACK, Style.YELLOW));
-        STYLES.put("BALT16", new Style(Shape.RECT, Style.BLACK, Style.YELLOW));
+        STYLES.put("TNL1", new Style(Shape.RECT, Style.parseColor("#ed1c24"), Style.WHITE)); // Tram
+        STYLES.put("TNL1E", new Style(Shape.RECT, Style.parseColor("#ed1c24"), Style.WHITE)); // Tram
+        STYLES.put("TNL2", new Style(Shape.RECT, Style.parseColor("#0071bc"), Style.WHITE)); // Tram
+        STYLES.put("TNL2E", new Style(Shape.RECT, Style.parseColor("#0071bc"), Style.WHITE)); // Tram
+        STYLES.put("BNL3", new Style(Shape.CIRCLE, Style.parseColor("#806a50"), Style.WHITE)); // Bus
+        STYLES.put("BNL11", new Style(Shape.RECT, Style.parseColor("#00aeef"), Style.WHITE)); // Anruf-Linien-Taxi
+        STYLES.put("BNL12", new Style(Shape.RECT, Style.parseColor("#2e3092"), Style.WHITE)); // Anruf-Linien-Taxi
+        STYLES.put("BNL13", new Style(Shape.RECT, Style.parseColor("#9b95c9"), Style.WHITE)); // Anruf-Linien-Taxi
+        STYLES.put("BNL14", new Style(Shape.RECT, Style.parseColor("#a25641"), Style.WHITE)); // Anruf-Linien-Taxi
+        STYLES.put("BNL15", new Style(Shape.RECT, Style.parseColor("#80c342"), Style.WHITE)); // Anruf-Linien-Taxi
+        STYLES.put("BNL16", new Style(Shape.RECT, Style.parseColor("#177752"), Style.WHITE)); // Anruf-Linien-Taxi
+        STYLES.put("BNL17", new Style(Shape.RECT, Style.parseColor("#574187"), Style.WHITE)); // Anruf-Linien-Taxi
     }
 }


### PR DESCRIPTION
Update of KVV line colours
- Trams: some lines have a slight change in the hex code; added tram 10 (temporary construction line)
- AVG tram-trains: removed not existing/former lines S3, S33, S41 (old), S9, added recently added lines S12, S41 (new) and S42
- S-Bahn Rhein-Neckar: added lines S1, S2, S44, S9
- reactivated/updated Karlsruhe urban bus colours: they are used, for example on bus stop signs and posters
- updated Nightliner line colours

Not sure if the colours for ALT and NL-ALT lines (day and night _Anruf-Sammel-Taxi_ lines) are applied when formatted like this, hope it works

Sources:

- [KVV rail map](https://www.kvv.de/fileadmin/user_upload/kvv/Dateien/Fahrplaene_Netzplaene/Schiene/2023/KVV-Liniennetzplan_Schiene.pdf)
- [AVG network map](https://www.kvv.de/fileadmin/user_upload/kvv/Dateien/Fahrplaene_Netzplaene/Schiene/2023/KVV-Liniennetzplan_Karlsruhe-Heilbronn.pdf)
- [Karlsruhe bus map](https://www.kvv.de/fileadmin/user_upload/kvv/Dateien/Fahrplaene_Netzplaene/Bus/2023/KVV-Liniennetzplan_Bus-und-Schiene_Karlsruhe.pdf)
- [Karlsruhe nightliner map](https://www.kvv.de/fileadmin/user_upload/kvv/Dateien/Fahrplaene_Netzplaene/Schiene/2023/KVV-Liniennetzplan_Nightliner.pdf)