### PR TITLE
AVV_Aachen: handle inconsistent place suffix for some stations

### DIFF
--- a/src/de/schildbach/pte/AvvAachenProvider.java
+++ b/src/de/schildbach/pte/AvvAachenProvider.java
@@ -46,11 +46,26 @@ public class AvvAachenProvider extends AbstractHafasClientInterfaceProvider {
         setApiAuthorization(apiAuthorization);
     }
 
+    private static final String[] PLACES = { "AC", "Aachen" };
+
     @Override
     protected String[] splitStationName(final String name) {
+        // Some stations in Aachen city have 3 names: "Aachen, station name", "station name, AC" and "AC, station name".
+        // Some (other) stations has 2 variants: "Aachen, station name" and "station name, Aachen"
+        // If you type the station name first, you get the variant "station name, AC" resp. "station name, Aachen",
+        // which would be parsed as a station AC resp. Aachen in "station name".
+        for (final String place: PLACES) {
+            if (name.endsWith(", " + place)) {
+                return new String[] { "Aachen" , name.substring(0, name.length() - place.length() - 2) };
+            }
+        }
         final Matcher m = P_SPLIT_NAME_FIRST_COMMA.matcher(name);
-        if (m.matches())
+        if (m.matches()) {
+            // also remove the abbreviating variant, just for consistency
+            if (m.group(1).equals("AC"))
+                return new String[] { "Aachen", m.group(2) };
             return new String[] { m.group(1), m.group(2) };
+        }
         return super.splitStationName(name);
     }
 

--- a/test/de/schildbach/pte/live/AvvAachenProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/AvvAachenProviderLiveTest.java
@@ -20,8 +20,10 @@ package de.schildbach.pte.live;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
+import java.util.Objects;
 
 import org.junit.Test;
 
@@ -72,6 +74,20 @@ public class AvvAachenProviderLiveTest extends AbstractProviderLiveTest {
         final SuggestLocationsResult result = suggestLocations("Gaßmühle");
         print(result);
         assertThat(result.getLocations(), hasItem(new Location(LocationType.STATION, "1576", "Aachen", "Gaßmühle")));
+    }
+
+    @Test
+    public void suggestLocationBadSuffix() throws Exception {
+        final SuggestLocationsResult result = suggestLocations("Turmstraße");
+        print(result);
+        assertTrue(Objects.requireNonNull(result.getLocations().get(0).name).contains("Turmstr"));
+    }
+
+    @Test
+    public void suggestLocationSpecialPlaceStationOrder() throws Exception {
+        final SuggestLocationsResult result = suggestLocations("Jupp-Müller");
+        print(result);
+        assertTrue(Objects.requireNonNull(result.getLocations().get(0).name).contains("Jupp-Müller"));
     }
 
     @Test


### PR DESCRIPTION
Some stations in Aachen have entries with the three differtent names "station name, AC", "Aachen, station name" and "AC, station name" in AVV's Hafas. Some others have "station name, Aachen" and "Aachen, station name". If you type the station name first, you get the variant "station name, AC" resp. "station name, Aachen" . Without the filter proposed here, the station name is parsed as "AC" (with place "station name"), which is not helpful in any abbreviating views, especially with multiple popular stations having this issue.
In Öffi for example when selecting such an entry for Bushof and Turmstraße: ![photo_2024-01-16_19-41-17](https://github.com/schildbach/public-transport-enabler/assets/1787847/ef6bfa09-905e-430c-88e5-1f4b27720493)

Meanwhile, for the route results, the API returns station names formatted "Aachen, station name" which looks fine.

This PR implements a filter for handling the station names ~~ending with ", AC" directly~~with "AC", ending in "Aachen" and a test checking the station name showing up at the correct place.