### PR TITLE
MVV: add new Munich S-Bahn line S5

### DIFF
--- a/src/de/schildbach/pte/MvvProvider.java
+++ b/src/de/schildbach/pte/MvvProvider.java
@@ -107,6 +107,7 @@ public class MvvProvider extends AbstractEfaProvider {
         STYLES.put("SS2", new Style(Shape.CIRCLE, Style.parseColor("#76b82a"), Style.WHITE));
         STYLES.put("SS3", new Style(Shape.CIRCLE, Style.parseColor("#951b81"), Style.WHITE));
         STYLES.put("SS4", new Style(Shape.CIRCLE, Style.parseColor("#e30613"), Style.WHITE));
+        STYLES.put("SS5", new Style(Shape.CIRCLE, Style.parseColor("#00527f"), Style.WHITE));
         STYLES.put("SS6", new Style(Shape.CIRCLE, Style.parseColor("#00975f"), Style.WHITE));
         STYLES.put("SS7", new Style(Shape.CIRCLE, Style.parseColor("#943126"), Style.WHITE));
         STYLES.put("SS8", new Style(Shape.CIRCLE, Style.BLACK, Style.parseColor("#ffcc00")));


### PR DESCRIPTION
Add new line that will run from December 2024
https://www.s-bahn-muenchen.de/fahren/s5