### PR TITLE
Fix MOT number and colours for Glasgow subway

### DIFF
--- a/src/de/schildbach/pte/TlemProvider.java
+++ b/src/de/schildbach/pte/TlemProvider.java
@@ -72,6 +72,17 @@ public class TlemProvider extends AbstractEfaProvider {
             if (trainType == null && ("DLR".equals(trainNum) || "Light Railway".equals(trainName)))
                 return new Line(id, network, Product.SUBURBAN_TRAIN, "DLR");
         }
+        if ("sco".equals(network) && "SUB".equals(symbol)){
+            String label = "SUB";
+            if (id!=null) {
+                if (id.contains("H")) {
+                    label = "OUT";
+                } else if (id.contains(("R"))) {
+                    label = "INN";
+                }
+            }
+            return new Line(id, network, Product.SUBWAY, label);
+        }
 
         return super.parseLine(id, network, mot, symbol, name, longName, trainType, trainNum, trainName);
     }
@@ -99,5 +110,9 @@ public class TlemProvider extends AbstractEfaProvider {
         STYLES.put("TTramlink 1", new Style(Style.rgb(193, 215, 46), Style.WHITE));
         STYLES.put("TTramlink 2", new Style(Style.rgb(193, 215, 46), Style.WHITE));
         STYLES.put("TTramlink 3", new Style(Style.rgb(124, 194, 66), Style.BLACK));
+
+        // Glasgow
+        STYLES.put("sco|UOUT", new Style(Style.parseColor("#f38b23"), Style.WHITE));
+        STYLES.put("sco|UINN", new Style(Style.parseColor("#585a5e"), Style.WHITE));
     }
 }


### PR DESCRIPTION
At the moment, the public-transport-enabler doesn't recognise the Glasgow subway (SPT) as a subway. This MR fixes that. While at it, it also changes the colours of the two subways lines to those used in the maps.

Official maps:

<img src="https://github.com/user-attachments/assets/19b213a0-4fae-4246-9a4c-7f3324e51dbd" height="500">

Before:

![before](https://github.com/user-attachments/assets/9b6d53f9-e528-45ca-a4ff-25a8f0441e3c)

After:
![after](https://github.com/user-attachments/assets/35f252d5-e995-44c7-92c7-bc1bff54bc45)