### PR TITLE
SE: Add SL color style

### DIFF
--- a/src/de/schildbach/pte/SeProvider.java
+++ b/src/de/schildbach/pte/SeProvider.java
@@ -47,6 +47,7 @@ public class SeProvider extends AbstractHafasClientInterfaceProvider {
         setApiVersion("1.18");
         setApiClient(apiClient);
         setApiAuthorization(apiAuthorization);
+        setStyles(STYLES);
     }
 
     private static final Pattern P_SPLIT_NAME_PAREN = Pattern.compile("(.*) \\((.{3,}?) kn\\)");
@@ -70,5 +71,55 @@ public class SeProvider extends AbstractHafasClientInterfaceProvider {
     @Override
     public Set<Product> defaultProducts() {
         return Product.ALL;
+    }
+    
+    private static final Map<String, Style> STYLES = new HashMap<>();
+
+    static {
+        // SL Tunnelbanan (Metro)
+        // Blue lines
+        STYLES.put("SL|ULänstrafik -Tunnelbana 10", new Style(Style.parseColor("#007db8"), Style.WHITE));
+        STYLES.put("SL|ULänstrafik -Tunnelbana 11", new Style(Style.parseColor("#007db8"), Style.WHITE));
+        // Red lines
+        STYLES.put("SL|ULänstrafik -Tunnelbana 13", new Style(Style.parseColor("#d71d24"), Style.WHITE));
+        STYLES.put("SL|ULänstrafik -Tunnelbana 14", new Style(Style.parseColor("#d71d24"), Style.WHITE));
+        // Green lines
+        STYLES.put("SL|ULänstrafik -Tunnelbana 17", new Style(Style.parseColor("#148541"), Style.WHITE));
+        STYLES.put("SL|ULänstrafik -Tunnelbana 18", new Style(Style.parseColor("#148541"), Style.WHITE));
+        STYLES.put("SL|ULänstrafik -Tunnelbana 19", new Style(Style.parseColor("#148541"), Style.WHITE));
+
+        // SL Pendeltåg (Commuter rail)
+        STYLES.put("SL|SLänstrafik - Tåg 40", new Style(Style.parseColor("#9a295c"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 41", new Style(Style.parseColor("#9a295c"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 42X", new Style(Style.parseColor("#9a295c"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 43", new Style(Style.parseColor("#9a295c"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 43X", new Style(Style.parseColor("#9a295c"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 48", new Style(Style.parseColor("#9a295c"), Style.WHITE));
+
+        // SL Spårvagn/Lokalbana (Tram/Light rail)
+        STYLES.put("SL|T7", new Style(Style.parseColor("#747770"), Style.WHITE));
+        STYLES.put("SL|T12", new Style(Style.parseColor("#627892"), Style.WHITE));
+        STYLES.put("SL|T21", new Style(Style.parseColor("#a54905"), Style.WHITE));
+        STYLES.put("SL|T30", new Style(Style.parseColor("#b65f1f"), Style.WHITE));
+        STYLES.put("SL|T31", new Style(Style.parseColor("#b65f1f"), Style.WHITE));
+
+        STYLES.put("SL|SLänstrafik - Tåg 25", new Style(Style.parseColor("#008f93"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 26", new Style(Style.parseColor("#008f93"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 27", new Style(Style.parseColor("#9f599a"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 28", new Style(Style.parseColor("#9f599a"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 28S", new Style(Style.parseColor("#9f599a"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 28X", new Style(Style.parseColor("#9f599a"), Style.WHITE));
+        STYLES.put("SL|SLänstrafik - Tåg 29", new Style(Style.parseColor("#9f599a"), Style.WHITE));
+
+        // SL Bät (Commuter ferry lines)
+        STYLES.put("SL|FLänstrafik - Färja 80", new Style(Style.parseColor("#007db8"), Style.WHITE));
+        STYLES.put("SL|FLänstrafik - Färja 82", new Style(Style.parseColor("#007db8"), Style.WHITE));
+        STYLES.put("SL|FLänstrafik - Färja 83", new Style(Style.parseColor("#007db8"), Style.WHITE));
+        STYLES.put("SL|FLänstrafik - Färja 83X", new Style(Style.parseColor("#007db8"), Style.WHITE));
+        STYLES.put("SL|FLänstrafik - Färja 84", new Style(Style.parseColor("#007db8"), Style.WHITE));
+        STYLES.put("SL|FLänstrafik - Färja 89", new Style(Style.parseColor("#007db8"), Style.WHITE));
+
+        // SL Buss (Buses)
+        STYLES.put("SL|B", new Style(Style.parseColor("#000000"), Style.WHITE));
     }
 }


### PR DESCRIPTION
This PR adds to the current SE (Swedish) provider line colors for the SL network (Storstockholms Lokaltrafik, public transportation in Stockholm Country). Colors have been retrieved from the [SL website](https://sl.se/).