### PR TITLE
API contract, DbProvider backwards compat

### DIFF
--- a/src/de/schildbach/pte/AbstractHafasClientInterfaceProvider.java
+++ b/src/de/schildbach/pte/AbstractHafasClientInterfaceProvider.java
@@ -312,7 +312,9 @@ public abstract class AbstractHafasClientInterfaceProvider extends AbstractHafas
         }
 
         final Calendar c = new GregorianCalendar(timeZone);
-        c.setTime(time);
+        if (time != null) {
+            c.setTime(time);
+        }
         final CharSequence jsonDate = jsonDate(c);
         final CharSequence jsonTime = jsonTime(c);
         final CharSequence normalizedStationId = normalizeStationId(stationId);

--- a/src/de/schildbach/pte/DbProvider.java
+++ b/src/de/schildbach/pte/DbProvider.java
@@ -163,6 +163,11 @@ public final class DbProvider extends AbstractNetworkProvider {
         this.resultHeader = new ResultHeader(network, "movas");
     }
 
+    // backwards compat
+    public DbProvider(final String apiClient, final String apiAuthorization, final byte[] salt) {
+        this();
+    }
+
     private String doRequest(final HttpUrl url, final String body, final String contentType) throws IOException {
         // DB API requires these headers
         // Content-Type must be exactly as passed below,
@@ -198,7 +203,6 @@ public final class DbProvider extends AbstractNetworkProvider {
             return null;
         return ISO_DATE_TIME_WOFFSET_FORMAT.format(time);
     }
-
 
     private Date parseIso8601WOffset(final String time) {
         if (time == null)
@@ -658,7 +662,9 @@ public final class DbProvider extends AbstractNetworkProvider {
         if (maxDepartures == 0)
             maxDepartures = DEFAULT_MAX_DEPARTURES;
         final Calendar c = new GregorianCalendar(timeZone);
-        c.setTime(time);
+        if (time != null) {
+            c.setTime(time);
+        }
 
         final String request = "{\"anfragezeit\": \"" + formatTime(c) + "\"," //
                 + "\"datum\": \"" + formatDate(c) + "\"," //

--- a/test/de/schildbach/pte/live/DbProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/DbProviderLiveTest.java
@@ -20,6 +20,7 @@ package de.schildbach.pte.live;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
 import java.util.EnumSet;
@@ -68,7 +69,8 @@ public class DbProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("692990", false);
+        final QueryDeparturesResult result = provider.queryDepartures("692990", null, 5, false);
+        assertTrue(result.stationDepartures.size() == 1);
         print(result);
     }
 


### PR DESCRIPTION
* resolves #638 
* adds back `DbProvider(String, String, byte[])` constructor for backwards compat with previous `DbProvider`