### PR TITLE
Location: expand list of non-unique names

### DIFF
--- a/src/de/schildbach/pte/dto/Location.java
+++ b/src/de/schildbach/pte/dto/Location.java
@@ -135,7 +135,8 @@ public final class Location implements Serializable {
     }
 
     private static final String[] NON_UNIQUE_NAMES = { "Hauptbahnhof", "Hbf", "Bahnhof", "Bf", "Busbahnhof", "ZOB",
-            "Schiffstation", "Schiffst.", "Zentrum", "Markt", "Dorf", "Kirche", "Nord", "Ost", "Süd", "West" };
+            "Schiffstation", "Schiffst.", "Zentrum", "Zentrum Bhf", "Markt", "Dorf", "Kirche", "Friedhof",
+            "Friedhof Bhf", "Nord", "Nord Bhf", "Ost", "Ost Bhf", "Süd", "Süd Bhf", "West", "West Bhf" };
 
     static {
         Arrays.sort(NON_UNIQUE_NAMES);


### PR DESCRIPTION
Personally, this PR is motivated by confusion over `Neuruppin, West Bhf` and `Hohen Neuendorf, West Bhf` with the BVG provider, but after finding the current special-casing of `NON_UNIQUE_NAMES`, I realized that this is not an isolated problem, so I added a few more generic station names that appear to be in use.