### PR TITLE
Add gradle-wrapper.properties for Gradle 4.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,3 +50,15 @@ compileTestJava {
 test {
     exclude 'de/schildbach/pte/live/**'
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = project.group
+            artifactId = archivesBaseName
+            version = project.version
+
+            from components.java
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https://services.gradle.org/distributions/gradle-4.4.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,1 +1,2 @@
 distributionUrl=https://services.gradle.org/distributions/gradle-4.4.1-bin.zip
+distributionSha256Sum=e7cf7d1853dfc30c1c44f571d3919eeeedef002823b66b6a988d27e919686389


### PR DESCRIPTION
#676
With that at least build on Jitpack will work and use the same Gradle version as CI