### PR TITLE
AVV_Aachen: Additional city abbreviations

### DIFF
--- a/src/de/schildbach/pte/AvvAachenProvider.java
+++ b/src/de/schildbach/pte/AvvAachenProvider.java
@@ -47,25 +47,39 @@ public class AvvAachenProvider extends AbstractHafasClientInterfaceProvider {
         setApiAuthorization(apiAuthorization);
     }
 
-    private static final String[] PLACES = { "AC", "Aachen" };
+    private String normalizePlaceName(final String place) {
+        // normalize abbreviations of place names, e.g. "AC" to "Aachen"
+        switch (place) {
+            case "AC":
+                return "Aachen";
+            case "DN":
+                return "Düren";
+            case "JÜL":
+                return "Jülich";
+            default:
+                return place;
+        }
+    }
+
+    private static final String[] PLACES = { "AC", "Aachen", "DN", "Düren", "JÜL", "Jülich" };
 
     @Override
     protected String[] splitStationName(final String name) {
-        // Some stations in Aachen city have 3 names: "Aachen, station name", "station name, AC" and "AC, station name".
+        // Some stations have 3 names: "Aachen, station name", "station name, AC" and "AC, station name".
         // Some (other) stations has 2 variants: "Aachen, station name" and "station name, Aachen"
         // If you type the station name first, you get the variant "station name, AC" resp. "station name, Aachen",
         // which would be parsed as a station AC resp. Aachen in "station name".
         for (final String place: PLACES) {
             if (name.endsWith(", " + place)) {
-                return new String[] { "Aachen" , name.substring(0, name.length() - place.length() - 2) };
+                String normalizedPlace = normalizePlaceName(place);
+                return new String[] { normalizedPlace , name.substring(0, name.length() - place.length() - 2) };
             }
         }
         final Matcher m = P_SPLIT_NAME_FIRST_COMMA.matcher(name);
         if (m.matches()) {
             // also remove the abbreviating variant, just for consistency
-            if (m.group(1).equals("AC"))
-                return new String[] { "Aachen", m.group(2) };
-            return new String[] { m.group(1), m.group(2) };
+            String normalizedPlace = normalizePlaceName(m.group(1));
+            return new String[] { normalizedPlace, m.group(2) };
         }
         return super.splitStationName(name);
     }

--- a/test/de/schildbach/pte/live/AvvAachenProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/AvvAachenProviderLiveTest.java
@@ -91,6 +91,14 @@ public class AvvAachenProviderLiveTest extends AbstractProviderLiveTest {
     }
 
     @Test
+    public void suggestLocationAbbrevPlace() throws Exception {
+        final SuggestLocationsResult result = suggestLocations("Walramplatz");
+        print(result);
+        assertTrue(Objects.requireNonNull(result.getLocations().get(0).name).contains("Walramplatz"));
+        assertTrue(Objects.requireNonNull(result.getLocations().get(0).place).contains("Jülich"));
+    }
+
+    @Test
     public void suggestLocationsPOI() throws Exception {
         final SuggestLocationsResult result = suggestLocations("Suermondt-Ludwig-Museum");
         print(result);


### PR DESCRIPTION
As already hinted in #554, there is more mess with station names. Here is another fix: DN and JÜL are also used to abbreviate cities

(POI and Address tests are failing, but they were failing before, see #712)