### PR TITLE
NetworkProvider: remove parameter `equivs` from `queryDepartures()`

### DIFF
--- a/src/de/schildbach/pte/AbstractEfaProvider.java
+++ b/src/de/schildbach/pte/AbstractEfaProvider.java
@@ -1472,14 +1472,14 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider {
 
     @Override
     public QueryDeparturesResult queryDepartures(final String stationId, final @Nullable Date time,
-            final int maxDepartures, final boolean equivs) throws IOException {
+            final int maxDepartures) throws IOException {
         requireNonNull(stationId);
 
-        return xsltDepartureMonitorRequest(stationId, time, maxDepartures, equivs);
+        return xsltDepartureMonitorRequest(stationId, time, maxDepartures);
     }
 
     protected void appendDepartureMonitorRequestParameters(final HttpUrl.Builder url, final String stationId,
-            final @Nullable Date time, final int maxDepartures, final boolean equivs) {
+            final @Nullable Date time, final int maxDepartures) {
         appendCommonRequestParams(url, "XML");
         url.addEncodedQueryParameter("type_dm", "stop");
         url.addEncodedQueryParameter("name_dm",
@@ -1489,9 +1489,9 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider {
         url.addEncodedQueryParameter("useRealtime", "1");
         url.addEncodedQueryParameter("mode", "direct");
         url.addEncodedQueryParameter("ptOptionsActive", "1");
-        url.addEncodedQueryParameter("deleteAssignedStops_dm", equivs ? "0" : "1");
+        url.addEncodedQueryParameter("deleteAssignedStops_dm", "1");
         if (useProxFootSearch)
-            url.addEncodedQueryParameter("useProxFootSearch", equivs ? "1" : "0");
+            url.addEncodedQueryParameter("useProxFootSearch", "0");
         url.addEncodedQueryParameter("mergeDep", "1"); // merge departures
         if (maxDepartures > 0)
             url.addEncodedQueryParameter("limit", Integer.toString(maxDepartures));
@@ -1510,9 +1510,9 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider {
     }
 
     private QueryDeparturesResult xsltDepartureMonitorRequest(final String stationId, final @Nullable Date time,
-            final int maxDepartures, final boolean equivs) throws IOException {
+            final int maxDepartures) throws IOException {
         final HttpUrl.Builder url = departureMonitorEndpoint.newBuilder();
-        appendDepartureMonitorRequestParameters(url, stationId, time, maxDepartures, equivs);
+        appendDepartureMonitorRequestParameters(url, stationId, time, maxDepartures);
         final AtomicReference<QueryDeparturesResult> result = new AtomicReference<>();
 
         final HttpClient.Callback callback = (bodyPeek, body) -> {
@@ -1653,9 +1653,9 @@ public abstract class AbstractEfaProvider extends AbstractNetworkProvider {
     }
 
     protected QueryDeparturesResult queryDeparturesMobile(final String stationId, final @Nullable Date time,
-            final int maxDepartures, final boolean equivs) throws IOException {
+            final int maxDepartures) throws IOException {
         final HttpUrl.Builder url = departureMonitorEndpoint.newBuilder();
-        appendDepartureMonitorRequestParameters(url, stationId, time, maxDepartures, equivs);
+        appendDepartureMonitorRequestParameters(url, stationId, time, maxDepartures);
         final AtomicReference<QueryDeparturesResult> result = new AtomicReference<>();
 
         final HttpClient.Callback callback = (bodyPeek, body) -> {

--- a/src/de/schildbach/pte/AbstractHafasClientInterfaceProvider.java
+++ b/src/de/schildbach/pte/AbstractHafasClientInterfaceProvider.java
@@ -169,8 +169,8 @@ public abstract class AbstractHafasClientInterfaceProvider extends AbstractHafas
 
     @Override
     public QueryDeparturesResult queryDepartures(final String stationId, final @Nullable Date time,
-            final int maxDepartures, final boolean equivs) throws IOException {
-        return jsonStationBoard(stationId, time, maxDepartures, equivs);
+            final int maxDepartures) throws IOException {
+        return jsonStationBoard(stationId, time, maxDepartures);
     }
 
     @Override
@@ -269,11 +269,11 @@ public abstract class AbstractHafasClientInterfaceProvider extends AbstractHafas
     }
 
     protected final QueryDeparturesResult jsonStationBoard(final String stationId, final @Nullable Date time,
-            int maxDepartures, final boolean equivs) throws IOException {
+            int maxDepartures) throws IOException {
         final boolean canStbFltrEquiv = apiVersion.compareToIgnoreCase("1.18") <= 0;
         if (maxDepartures == 0)
             maxDepartures = DEFAULT_MAX_DEPARTURES;
-        if (!equivs && !canStbFltrEquiv) {
+        if (!canStbFltrEquiv) {
             final int raisedMaxDepartures = maxDepartures * 4;
             log.info("stbFltrEquiv workaround in effect: querying for {} departures rather than {}",
                     raisedMaxDepartures, maxDepartures);
@@ -291,7 +291,7 @@ public abstract class AbstractHafasClientInterfaceProvider extends AbstractHafas
                 + "\"time\":\"" + jsonTime + "\"," //
                 + "\"stbLoc\":{\"type\":\"S\"," + "\"state\":\"F\"," // F/M
                 + "\"extId\":" + JSONObject.quote(normalizedStationId.toString()) + "}," //
-                + (canStbFltrEquiv ? "\"stbFltrEquiv\":" + Boolean.toString(!equivs) + "," : "") //
+                + (canStbFltrEquiv ? "\"stbFltrEquiv\":true," : "") //
                 + "\"maxJny\":" + maxJny + "}", false);
 
         final HttpUrl url = requestUrl(request);
@@ -366,7 +366,7 @@ public abstract class AbstractHafasClientInterfaceProvider extends AbstractHafas
 
                     final Location location = parseLoc(locList, stbStop.getInt("locX"), null, crdSysList);
                     checkState(location.type == LocationType.STATION);
-                    if (!equivs && !location.id.equals(stationId))
+                    if (!location.id.equals(stationId))
                         continue;
 
                     final String jnyDirTxt = jny.optString("dirTxt", null);

--- a/src/de/schildbach/pte/AbstractHafasLegacyProvider.java
+++ b/src/de/schildbach/pte/AbstractHafasLegacyProvider.java
@@ -104,7 +104,6 @@ public abstract class AbstractHafasLegacyProvider extends AbstractHafasProvider 
     private boolean useIso8601 = false;
     private boolean stationBoardHasStationTable = true;
     private boolean stationBoardHasLocation = false;
-    private boolean stationBoardCanDoEquivs = true;
 
     @SuppressWarnings("serial")
     private static class Context implements QueryTripsContext {
@@ -223,11 +222,6 @@ public abstract class AbstractHafasLegacyProvider extends AbstractHafasProvider 
 
     protected AbstractHafasProvider setStationBoardHasLocation(final boolean stationBoardHasLocation) {
         this.stationBoardHasLocation = stationBoardHasLocation;
-        return this;
-    }
-
-    protected AbstractHafasProvider setStationBoardCanDoEquivs(final boolean canDoEquivs) {
-        this.stationBoardCanDoEquivs = canDoEquivs;
         return this;
     }
 
@@ -388,20 +382,19 @@ public abstract class AbstractHafasLegacyProvider extends AbstractHafasProvider 
 
     @Override
     public QueryDeparturesResult queryDepartures(final String stationId, final @Nullable Date time,
-            final int maxDepartures, final boolean equivs) throws IOException {
+            final int maxDepartures) throws IOException {
         requireNonNull(stationId);
 
         final HttpUrl.Builder url = stationBoardEndpoint.newBuilder().addPathSegment(apiLanguage);
-        appendXmlStationBoardParameters(url, time, stationId, maxDepartures, equivs, "vs_java3");
+        appendXmlStationBoardParameters(url, time, stationId, maxDepartures,"vs_java3");
         return xmlStationBoard(url.build(), stationId);
     }
 
     protected void appendXmlStationBoardParameters(final HttpUrl.Builder url, final @Nullable Date time,
-            final String stationId, final int maxDepartures, final boolean equivs, final @Nullable String styleSheet) {
+            final String stationId, final int maxDepartures, final @Nullable String styleSheet) {
         url.addQueryParameter("productsFilter", allProductsString().toString());
         url.addQueryParameter("boardType", "dep");
-        if (stationBoardCanDoEquivs)
-            url.addQueryParameter("disableEquivs", equivs ? "0" : "1");
+        url.addQueryParameter("disableEquivs", "1");
         url.addQueryParameter("maxJourneys",
                 Integer.toString(maxDepartures > 0 ? maxDepartures : DEFAULT_MAX_DEPARTURES));
         url.addEncodedQueryParameter("input", ParserUtils.urlEncode(normalizeStationId(stationId), requestUrlEncoding));
@@ -624,7 +617,7 @@ public abstract class AbstractHafasLegacyProvider extends AbstractHafasProvider 
                                 capacity, message);
 
                         final Location location;
-                        if (!stationBoardCanDoEquivs || depStation == null) {
+                        if (depStation == null) {
                             location = new Location(LocationType.STATION, normalizedStationId,
                                     stationPlaceAndName != null ? stationPlaceAndName[0] : null,
                                     stationPlaceAndName != null ? stationPlaceAndName[1] : null);

--- a/src/de/schildbach/pte/BayernProvider.java
+++ b/src/de/schildbach/pte/BayernProvider.java
@@ -127,10 +127,10 @@ public class BayernProvider extends AbstractEfaProvider {
 
     @Override
     public QueryDeparturesResult queryDepartures(final String stationId, final @Nullable Date time,
-            final int maxDepartures, final boolean equivs) throws IOException {
+            final int maxDepartures) throws IOException {
         requireNonNull(stationId);
 
-        return queryDeparturesMobile(stationId, time, maxDepartures, equivs);
+        return queryDeparturesMobile(stationId, time, maxDepartures);
     }
 
     @Override

--- a/src/de/schildbach/pte/DbProvider.java
+++ b/src/de/schildbach/pte/DbProvider.java
@@ -651,8 +651,7 @@ public final class DbProvider extends AbstractNetworkProvider {
     }
 
     @Override
-    public QueryDeparturesResult queryDepartures(String stationId, @Nullable Date time, int maxDepartures,
-            boolean equivs)
+    public QueryDeparturesResult queryDepartures(String stationId, @Nullable Date time, int maxDepartures)
             throws IOException {
         // TODO only 1 hour of results returned, find secret parameter?
         if (maxDepartures == 0)
@@ -681,7 +680,7 @@ public final class DbProvider extends AbstractNetworkProvider {
                     continue;
                 }
                 final Location l = parseLocation(dep.optJSONObject("abfrageOrt"));
-                if (!equivs && !stationId.equals(l.id)) {
+                if (!stationId.equals(l.id)) {
                     continue;
                 }
                 StationDepartures stationDepartures = result.findStationDepartures(l.id);

--- a/src/de/schildbach/pte/NegentweeProvider.java
+++ b/src/de/schildbach/pte/NegentweeProvider.java
@@ -769,8 +769,7 @@ public class NegentweeProvider extends AbstractNetworkProvider {
     }
 
     @Override
-    public QueryDeparturesResult queryDepartures(String stationId, @Nullable Date time, int maxDepartures,
-            boolean equivs) throws IOException {
+    public QueryDeparturesResult queryDepartures(String stationId, @Nullable Date time, int maxDepartures) throws IOException {
         // The stationId does not need the / character escaped
         HttpUrl url = buildApiUrl("locations/" + stationId + "/departure-times", new ArrayList<QueryParameter>());
         final CharSequence page;
@@ -793,8 +792,8 @@ public class NegentweeProvider extends AbstractNetworkProvider {
                 for (int l = 0; l < locations.length(); l++) {
                     JSONObject location = locations.getJSONObject(l);
 
-                    // Ignore if equivs is false and stationId is not a strict match
-                    if (!equivs && !location.getString("id").equals(stationId)) {
+                    // Ignore stationId is not a strict match
+                    if (!location.getString("id").equals(stationId)) {
                         continue;
                     }
 

--- a/src/de/schildbach/pte/NetworkProvider.java
+++ b/src/de/schildbach/pte/NetworkProvider.java
@@ -101,12 +101,10 @@ public interface NetworkProvider {
      *            desired time for departing, or {@code null} for the provider default
      * @param maxDepartures
      *            maximum number of departures to get or {@code 0}
-     * @param equivs
-     *            also query equivalent stations?
      * @return result object containing the departures
      * @throws IOException
      */
-    QueryDeparturesResult queryDepartures(String stationId, @Nullable Date time, int maxDepartures, boolean equivs)
+    QueryDeparturesResult queryDepartures(String stationId, @Nullable Date time, int maxDepartures)
             throws IOException;
 
     /**

--- a/src/de/schildbach/pte/VrsProvider.java
+++ b/src/de/schildbach/pte/VrsProvider.java
@@ -408,10 +408,8 @@ public class VrsProvider extends AbstractNetworkProvider {
         }
     }
 
-    // TODO equivs not supported; JSON result would support multiple timetables
     @Override
-    public QueryDeparturesResult queryDepartures(final String stationId, @Nullable Date time, int maxDepartures,
-            boolean equivs) throws IOException {
+    public QueryDeparturesResult queryDepartures(final String stationId, @Nullable Date time, int maxDepartures) throws IOException {
         requireNonNull(stationId);
 
         // g=p means group by product; not used here

--- a/src/de/schildbach/pte/VvmProvider.java
+++ b/src/de/schildbach/pte/VvmProvider.java
@@ -64,10 +64,10 @@ public class VvmProvider extends AbstractEfaProvider {
 
     @Override
     public QueryDeparturesResult queryDepartures(final String stationId, final @Nullable Date time,
-                                                 final int maxDepartures, final boolean equivs) throws IOException {
+                                                 final int maxDepartures) throws IOException {
         requireNonNull(stationId);
 
-        return queryDeparturesMobile(stationId, time, maxDepartures, equivs);
+        return queryDeparturesMobile(stationId, time, maxDepartures);
     }
 
     @Override

--- a/test/de/schildbach/pte/live/AbstractProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/AbstractProviderLiveTest.java
@@ -95,20 +95,16 @@ public abstract class AbstractProviderLiveTest {
         return provider.queryNearbyLocations(types, location, maxDistance, maxStations);
     }
 
-    protected final QueryDeparturesResult queryDepartures(final String stationId, final boolean equivs)
+    protected final QueryDeparturesResult queryDepartures(final String stationId)
             throws IOException {
-        return queryDepartures(stationId, 5, equivs);
+        return queryDepartures(stationId, 5);
     }
 
-    protected final QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures,
-            final boolean equivs) throws IOException {
-        final QueryDeparturesResult result = provider.queryDepartures(stationId, new Date(), maxDepartures, equivs);
+    protected final QueryDeparturesResult queryDepartures(final String stationId, final int maxDepartures) throws IOException {
+        final QueryDeparturesResult result = provider.queryDepartures(stationId, new Date(), maxDepartures);
 
         if (result.status == QueryDeparturesResult.Status.OK) {
-            if (equivs)
-                assertTrue(result.stationDepartures.size() > 1);
-            else
-                assertTrue(result.stationDepartures.size() == 1);
+            assertTrue(result.stationDepartures.size() == 1);
         }
 
         return result;

--- a/test/de/schildbach/pte/live/AvvAachenProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/AvvAachenProviderLiveTest.java
@@ -51,14 +51,14 @@ public class AvvAachenProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("1008", false);
+        final QueryDeparturesResult result = queryDepartures("1008");
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/AvvAugsburgProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/AvvAugsburgProviderLiveTest.java
@@ -52,13 +52,13 @@ public class AvvAugsburgProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8000013", false); // Hbf
+        final QueryDeparturesResult result = queryDepartures("8000013"); // Hbf
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/BartProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/BartProviderLiveTest.java
@@ -48,13 +48,13 @@ public class BartProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("100013295", false);
+        final QueryDeparturesResult result = queryDepartures("100013295");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/BayernProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/BayernProviderLiveTest.java
@@ -68,25 +68,25 @@ public class BayernProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult munichMarienplatz = queryDepartures("91000002", false);
+        final QueryDeparturesResult munichMarienplatz = queryDepartures("91000002");
         print(munichMarienplatz);
 
-        final QueryDeparturesResult munichHauptbahnhof = queryDepartures("91000006", false);
+        final QueryDeparturesResult munichHauptbahnhof = queryDepartures("91000006");
         print(munichHauptbahnhof);
 
-        final QueryDeparturesResult nurembergHauptbahnhof = queryDepartures("80001020", false);
+        final QueryDeparturesResult nurembergHauptbahnhof = queryDepartures("80001020");
         print(nurembergHauptbahnhof);
 
-        final QueryDeparturesResult augsburgAfrabruecke = queryDepartures("2000770", false);
+        final QueryDeparturesResult augsburgAfrabruecke = queryDepartures("2000770");
         print(augsburgAfrabruecke);
 
-        final QueryDeparturesResult ingolstadtHbf = queryDepartures("80000706", false);
+        final QueryDeparturesResult ingolstadtHbf = queryDepartures("80000706");
         print(ingolstadtHbf);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/BsvagProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/BsvagProviderLiveTest.java
@@ -56,13 +56,13 @@ public class BsvagProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("26000256", false);
+        final QueryDeparturesResult result = queryDepartures("26000256");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/BvgProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/BvgProviderLiveTest.java
@@ -64,49 +64,42 @@ public class BvgProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDeparturesWilmsstrasse() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900016254", false);
+        final QueryDeparturesResult result = queryDepartures("900016254");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesAlexanderplatzBhf() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900100003", false);
+        final QueryDeparturesResult result = queryDepartures("900100003");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesAlexanderplatzU2() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900100703", false);
+        final QueryDeparturesResult result = queryDepartures("900100703");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesAlexanderplatzU5() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900100704", false);
+        final QueryDeparturesResult result = queryDepartures("900100704");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesAlexanderplatzU8() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900100705", false);
+        final QueryDeparturesResult result = queryDepartures("900100705");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
-    public void queryDeparturesEquivs() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900100003", true);
-        print(result);
-        assertTrue(result.stationDepartures.size() > 1);
-    }
-
-    @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/DbProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/DbProviderLiveTest.java
@@ -68,13 +68,13 @@ public class DbProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("692990", false);
+        final QueryDeparturesResult result = queryDepartures("692990");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult resultLive = queryDepartures("999999", false);
+        final QueryDeparturesResult resultLive = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, resultLive.status);
     }
 

--- a/test/de/schildbach/pte/live/DingProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/DingProviderLiveTest.java
@@ -56,13 +56,13 @@ public class DingProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("90001611", false);
+        final QueryDeparturesResult result = queryDepartures("90001611");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/DsbProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/DsbProviderLiveTest.java
@@ -48,13 +48,13 @@ public class DsbProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("860430302", false);
+        final QueryDeparturesResult result = queryDepartures("860430302");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/GvhProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/GvhProviderLiveTest.java
@@ -57,13 +57,13 @@ public class GvhProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("25000031", false);
+        final QueryDeparturesResult result = queryDepartures("25000031");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/InvgProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/InvgProviderLiveTest.java
@@ -53,13 +53,13 @@ public class InvgProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("80301", false);
+        final QueryDeparturesResult result = queryDepartures("80301");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/KvvProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/KvvProviderLiveTest.java
@@ -57,19 +57,19 @@ public class KvvProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("7000090", false);
+        final QueryDeparturesResult result = queryDepartures("7000090");
         print(result);
     }
 
     @Test
     public void queryDeparturesMesseKarlsruhe() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("7000211", false);
+        final QueryDeparturesResult result = queryDepartures("7000211");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/LinzProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/LinzProviderLiveTest.java
@@ -54,13 +54,13 @@ public class LinzProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("60501720", false);
+        final QueryDeparturesResult result = queryDepartures("60501720");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/LuProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/LuProviderLiveTest.java
@@ -48,13 +48,13 @@ public class LuProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("200501001", false);
+        final QueryDeparturesResult result = queryDepartures("200501001");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/MerseyProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/MerseyProviderLiveTest.java
@@ -64,13 +64,13 @@ public class MerseyProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("4017846", false);
+        final QueryDeparturesResult result = queryDepartures("4017846");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult resultLive = queryDepartures("999999", false);
+        final QueryDeparturesResult resultLive = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, resultLive.status);
     }
 

--- a/test/de/schildbach/pte/live/MvgProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/MvgProviderLiveTest.java
@@ -56,13 +56,13 @@ public class MvgProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("3", false);
+        final QueryDeparturesResult result = queryDepartures("3");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/MvvProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/MvvProviderLiveTest.java
@@ -69,14 +69,14 @@ public class MvvProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDeparturesMarienplatz() throws Exception {
-        final QueryDeparturesResult result1 = queryDepartures("91000002", false);
+        final QueryDeparturesResult result1 = queryDepartures("91000002");
         assertEquals(QueryDeparturesResult.Status.OK, result1.status);
         print(result1);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/NasaProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/NasaProviderLiveTest.java
@@ -59,19 +59,13 @@ public class NasaProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("13000", false);
-        print(result);
-    }
-
-    @Test
-    public void queryDeparturesEquivs() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("13000", true);
+        final QueryDeparturesResult result = queryDepartures("13000");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/NegentweeProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/NegentweeProviderLiveTest.java
@@ -75,21 +75,14 @@ public class NegentweeProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("station-amsterdam-centraal", false);
-        print(result);
-        assertEquals(QueryDeparturesResult.Status.OK, result.status);
-    }
-
-    @Test
-    public void queryDeparturesWithEquivalents() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("station-amsterdam-centraal", true);
+        final QueryDeparturesResult result = queryDepartures("station-amsterdam-centraal");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/NsProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/NsProviderLiveTest.java
@@ -53,13 +53,13 @@ public class NsProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8800004", false);
+        final QueryDeparturesResult result = queryDepartures("8800004");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/NvbwProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/NvbwProviderLiveTest.java
@@ -81,31 +81,31 @@ public class NvbwProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDeparturesStuttgart() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("5006022", false); // Schlossplatz
+        final QueryDeparturesResult result = queryDepartures("5006022"); // Schlossplatz
         print(result);
     }
 
     @Test
     public void queryDeparturesReutlingen() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("53019174", false); // Reutlingen
+        final QueryDeparturesResult result = queryDepartures("53019174"); // Reutlingen
         print(result);
     }
 
     @Test
     public void queryDeparturesKarlsruhe() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("7000211", false); // Messe
+        final QueryDeparturesResult result = queryDepartures("7000211"); // Messe
         print(result);
     }
 
     @Test
     public void queryDeparturesFreiburg() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("6930112", false); // Faulerstraße
+        final QueryDeparturesResult result = queryDepartures("6930112"); // Faulerstraße
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/NvvProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/NvvProviderLiveTest.java
@@ -60,28 +60,22 @@ public class NvvProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("3000408", false);
+        final QueryDeparturesResult result = queryDepartures("3000408");
         print(result);
 
-        final QueryDeparturesResult result2 = queryDepartures("3000010", false);
+        final QueryDeparturesResult result2 = queryDepartures("3000010");
         print(result2);
 
-        final QueryDeparturesResult result3 = queryDepartures("3015989", false);
+        final QueryDeparturesResult result3 = queryDepartures("3015989");
         print(result3);
 
-        final QueryDeparturesResult result4 = queryDepartures("3000139", false);
+        final QueryDeparturesResult result4 = queryDepartures("3000139");
         print(result4);
     }
 
     @Test
-    public void queryDeparturesEquivs() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("3000010", true);
-        print(result);
-    }
-
-    @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/OebbProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/OebbProviderLiveTest.java
@@ -51,7 +51,7 @@ public class OebbProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("902006", false);
+        final QueryDeparturesResult result = queryDepartures("902006");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
         assertTrue(result.stationDepartures.size() > 0);
@@ -59,7 +59,7 @@ public class OebbProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/OoevvProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/OoevvProviderLiveTest.java
@@ -57,20 +57,20 @@ public class OoevvProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDeparturesLinz() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("444116400", 0, false);
+        final QueryDeparturesResult result = queryDepartures("444116400", 0);
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesSalzburg() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("455000200", false);
+        final QueryDeparturesResult result = queryDepartures("455000200");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", 0, false);
+        final QueryDeparturesResult result = queryDepartures("999999", 0);
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/PlProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/PlProviderLiveTest.java
@@ -53,13 +53,13 @@ public class PlProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("5100065", false);
+        final QueryDeparturesResult result = queryDepartures("5100065");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/RmvProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/RmvProviderLiveTest.java
@@ -55,28 +55,22 @@ public class RmvProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("3000408", false);
+        final QueryDeparturesResult result = queryDepartures("3000408");
         print(result);
 
-        final QueryDeparturesResult result2 = queryDepartures("3000010", false);
+        final QueryDeparturesResult result2 = queryDepartures("3000010");
         print(result2);
 
-        final QueryDeparturesResult result3 = queryDepartures("3015989", false);
+        final QueryDeparturesResult result3 = queryDepartures("3015989");
         print(result3);
 
-        final QueryDeparturesResult result4 = queryDepartures("3000139", false);
+        final QueryDeparturesResult result4 = queryDepartures("3000139");
         print(result4);
     }
 
     @Test
-    public void queryDeparturesEquivs() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("3000010", true);
-        print(result);
-    }
-
-    @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/RtProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/RtProviderLiveTest.java
@@ -54,13 +54,13 @@ public class RtProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8588344", false);
+        final QueryDeparturesResult result = queryDepartures("8588344");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/SeProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/SeProviderLiveTest.java
@@ -50,13 +50,13 @@ public class SeProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("740017515", false);
+        final QueryDeparturesResult result = queryDepartures("740017515");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/ShProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/ShProviderLiveTest.java
@@ -61,13 +61,13 @@ public class ShProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8002547", false);
+        final QueryDeparturesResult result = queryDepartures("8002547");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/StvProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/StvProviderLiveTest.java
@@ -56,13 +56,13 @@ public class StvProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDeparturesGraz() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("460304000", false);
+        final QueryDeparturesResult result = queryDepartures("460304000");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/SvvProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/SvvProviderLiveTest.java
@@ -51,13 +51,13 @@ public class SvvProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("455000200", false);
+        final QueryDeparturesResult result = queryDepartures("455000200");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", 0, false);
+        final QueryDeparturesResult result = queryDepartures("999999", 0);
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/SydneyProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/SydneyProviderLiveTest.java
@@ -54,25 +54,25 @@ public class SydneyProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDeparturesTownHall() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("10101101", false);
+        final QueryDeparturesResult result = queryDepartures("10101101");
         print(result);
     }
 
     @Test
     public void queryDeparturesCircularQuay() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("10101103", false);
+        final QueryDeparturesResult result = queryDepartures("10101103");
         print(result);
     }
 
     @Test
     public void queryDeparturesConvention() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("10101439", false);
+        final QueryDeparturesResult result = queryDepartures("10101439");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/TlemProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/TlemProviderLiveTest.java
@@ -58,22 +58,16 @@ public class TlemProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result1 = queryDepartures("1001003", false);
+        final QueryDeparturesResult result1 = queryDepartures("1001003");
         print(result1);
 
-        final QueryDeparturesResult result2 = queryDepartures("1000086", false);
+        final QueryDeparturesResult result2 = queryDepartures("1000086");
         print(result2);
     }
 
     @Test
-    public void queryDeparturesEquivs() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("1001003", true);
-        print(result);
-    }
-
-    @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult resultLive = queryDepartures("999999", false);
+        final QueryDeparturesResult resultLive = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, resultLive.status);
     }
 

--- a/test/de/schildbach/pte/live/VaoProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VaoProviderLiveTest.java
@@ -57,20 +57,20 @@ public class VaoProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("480082200", 0, false);
+        final QueryDeparturesResult result = queryDepartures("480082200", 0);
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesSalzburg() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("455000200", false);
+        final QueryDeparturesResult result = queryDepartures("455000200");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", 0, false);
+        final QueryDeparturesResult result = queryDepartures("999999", 0);
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VbbProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VbbProviderLiveTest.java
@@ -52,51 +52,44 @@ public class VbbProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900007102", false);
+        final QueryDeparturesResult result = queryDepartures("900007102");
         print(result);
     }
 
     @Test
     public void queryDeparturesAlexanderplatzBhf() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900100003", false);
+        final QueryDeparturesResult result = queryDepartures("900100003");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesAlexanderplatzU2() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900100703", false);
+        final QueryDeparturesResult result = queryDepartures("900100703");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesAlexanderplatzU5() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900100704", false);
+        final QueryDeparturesResult result = queryDepartures("900100704");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesAlexanderplatzU8() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900100705", false);
+        final QueryDeparturesResult result = queryDepartures("900100705");
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
-    public void queryDeparturesEquivs() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("900100003", true);
-        print(result);
-        assertTrue(result.stationDepartures.size() > 1);
-    }
-
-    @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult resultLive = queryDepartures("111111", false);
+        final QueryDeparturesResult resultLive = queryDepartures("111111");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, resultLive.status);
 
-        final QueryDeparturesResult resultPlan = queryDepartures("2449475", false);
+        final QueryDeparturesResult resultPlan = queryDepartures("2449475");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, resultPlan.status);
     }
 

--- a/test/de/schildbach/pte/live/VblProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VblProviderLiveTest.java
@@ -55,13 +55,13 @@ public class VblProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("717", false);
+        final QueryDeparturesResult result = queryDepartures("717");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VbnProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VbnProviderLiveTest.java
@@ -56,32 +56,25 @@ public class VbnProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDeparturesFreudenstadt() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8000110", false);
+        final QueryDeparturesResult result = queryDepartures("8000110");
         print(result);
     }
 
     @Test
     public void queryDeparturesGoettingen() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8000128", false);
+        final QueryDeparturesResult result = queryDepartures("8000128");
         print(result);
     }
 
     @Test
     public void queryDeparturesRostockHbf() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8010304", false);
+        final QueryDeparturesResult result = queryDepartures("8010304");
         print(result);
-    }
-
-    @Test
-    public void queryDeparturesEquivs() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8010304", true);
-        print(result);
-        assertTrue(result.stationDepartures.size() > 1);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VgnProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VgnProviderLiveTest.java
@@ -56,13 +56,13 @@ public class VgnProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("3000510", false);
+        final QueryDeparturesResult result = queryDepartures("3000510");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VgsProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VgsProviderLiveTest.java
@@ -59,13 +59,13 @@ public class VgsProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8000244", false);
+        final QueryDeparturesResult result = queryDepartures("8000244");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VmobilProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VmobilProviderLiveTest.java
@@ -57,20 +57,20 @@ public class VmobilProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("480082200", 0, false);
+        final QueryDeparturesResult result = queryDepartures("480082200", 0);
         print(result);
         assertEquals(QueryDeparturesResult.Status.OK, result.status);
     }
 
     @Test
     public void queryDeparturesSalzburg() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("455000200", false);
+        final QueryDeparturesResult result = queryDepartures("455000200");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", 0, false);
+        final QueryDeparturesResult result = queryDepartures("999999", 0);
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VmtProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VmtProviderLiveTest.java
@@ -54,13 +54,13 @@ public class VmtProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("153166", false);
+        final QueryDeparturesResult result = queryDepartures("153166");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VmvProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VmvProviderLiveTest.java
@@ -55,13 +55,13 @@ public class VmvProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("80001834", false);
+        final QueryDeparturesResult result = queryDepartures("80001834");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VorProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VorProviderLiveTest.java
@@ -51,13 +51,13 @@ public class VorProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("490134900", false);
+        final QueryDeparturesResult result = queryDepartures("490134900");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", 0, false);
+        final QueryDeparturesResult result = queryDepartures("999999", 0);
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VrnProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VrnProviderLiveTest.java
@@ -63,16 +63,16 @@ public class VrnProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result1 = queryDepartures("6032236", false);
+        final QueryDeparturesResult result1 = queryDepartures("6032236");
         print(result1);
 
-        final QueryDeparturesResult result2 = queryDepartures("17001301", false);
+        final QueryDeparturesResult result2 = queryDepartures("17001301");
         print(result2);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VrrProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VrrProviderLiveTest.java
@@ -67,27 +67,21 @@ public class VrrProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("1007258", false);
+        final QueryDeparturesResult result = queryDepartures("1007258");
         print(result);
 
-        final QueryDeparturesResult result2 = queryDepartures("20019904", false);
+        final QueryDeparturesResult result2 = queryDepartures("20019904");
         print(result2);
 
         // Bonn
-        queryDepartures("22000687", false); // Hauptbahnhof
-        queryDepartures("22001374", false); // Suedwache
+        queryDepartures("22000687"); // Hauptbahnhof
+        queryDepartures("22001374"); // Suedwache
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
-    }
-
-    @Test
-    public void queryManyDeparturesWithEquivs() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("20018235", true);
-        print(result);
     }
 
     @Test

--- a/test/de/schildbach/pte/live/VrsProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VrsProviderLiveTest.java
@@ -149,28 +149,28 @@ public class VrsProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDeparturesBonnHbf() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("687", false);
+        final QueryDeparturesResult result = queryDepartures("687");
         print(result);
         printLineDestinations(result);
     }
 
     @Test
     public void queryDeparturesKoelnHbf() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8", false);
+        final QueryDeparturesResult result = queryDepartures("8");
         print(result);
         printLineDestinations(result);
     }
 
     @Test
     public void queryDeparturesGaussstr() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8984", false);
+        final QueryDeparturesResult result = queryDepartures("8984");
         print(result);
         printLineDestinations(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 
@@ -180,7 +180,7 @@ public class VrsProviderLiveTest extends AbstractProviderLiveTest {
         for (int i = 0; i < 10; i++) {
             Integer id = 1 + rand.nextInt(20000);
             try {
-                final QueryDeparturesResult result = queryDepartures(id.toString(), false);
+                final QueryDeparturesResult result = queryDepartures(id.toString());
                 if (result.status == QueryDeparturesResult.Status.OK) {
                     print(result);
                     printLineDestinations(result);
@@ -526,7 +526,7 @@ public class VrsProviderLiveTest extends AbstractProviderLiveTest {
         }
         Set<Line> lines = new TreeSet<>();
         for (Location station : stations) {
-            QueryDeparturesResult qdr = provider.queryDepartures(station.id, new Date(), 100, false);
+            QueryDeparturesResult qdr = provider.queryDepartures(station.id, new Date(), 100);
             if (qdr.status == QueryDeparturesResult.Status.OK) {
                 for (StationDepartures stationDepartures : qdr.stationDepartures) {
                     final List<LineDestination> stationDeparturesLines = stationDepartures.lines;

--- a/test/de/schildbach/pte/live/VvmProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VvmProviderLiveTest.java
@@ -57,13 +57,13 @@ public class VvmProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("3000152", false);
+        final QueryDeparturesResult result = queryDepartures("3000152");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VvoProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VvoProviderLiveTest.java
@@ -57,13 +57,13 @@ public class VvoProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("100", false);
+        final QueryDeparturesResult result = queryDepartures("100");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VvsProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VvsProviderLiveTest.java
@@ -57,13 +57,13 @@ public class VvsProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("6118", false);
+        final QueryDeparturesResult result = queryDepartures("6118");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VvtProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VvtProviderLiveTest.java
@@ -51,13 +51,13 @@ public class VvtProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("470118700", false);
+        final QueryDeparturesResult result = queryDepartures("470118700");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", 0, false);
+        final QueryDeparturesResult result = queryDepartures("999999", 0);
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/VvvProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/VvvProviderLiveTest.java
@@ -55,13 +55,13 @@ public class VvvProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("80007271", false);
+        final QueryDeparturesResult result = queryDepartures("80007271");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/WienProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/WienProviderLiveTest.java
@@ -66,13 +66,13 @@ public class WienProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("60203090", false);
+        final QueryDeparturesResult result = queryDepartures("60203090");
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 

--- a/test/de/schildbach/pte/live/ZvvProviderLiveTest.java
+++ b/test/de/schildbach/pte/live/ZvvProviderLiveTest.java
@@ -48,31 +48,31 @@ public class ZvvProviderLiveTest extends AbstractProviderLiveTest {
 
     @Test
     public void queryDepartures() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8503000", false); // Hauptbahnhof
+        final QueryDeparturesResult result = queryDepartures("8503000"); // Hauptbahnhof
         print(result);
     }
 
     @Test
     public void queryDeparturesSuburbanTrain() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8500169", false); // Muriaux
+        final QueryDeparturesResult result = queryDepartures("8500169"); // Muriaux
         print(result);
     }
 
     @Test
     public void queryDeparturesTram() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8591276", false); // Milchbuck
+        final QueryDeparturesResult result = queryDepartures("8591276"); // Milchbuck
         print(result);
     }
 
     @Test
     public void queryDeparturesTrolley() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("8591177", false); // Hardplatz
+        final QueryDeparturesResult result = queryDepartures("8591177"); // Hardplatz
         print(result);
     }
 
     @Test
     public void queryDeparturesInvalidStation() throws Exception {
-        final QueryDeparturesResult result = queryDepartures("999999", false);
+        final QueryDeparturesResult result = queryDepartures("999999");
         assertEquals(QueryDeparturesResult.Status.INVALID_STATION, result.status);
     }
 


### PR DESCRIPTION
The concept is badly defined between providers and a headache to maintain. On modern APIs with hierarchical locations (station, stop, position), you'd better query on a "higher level".

This also removes the `stationBoardCanDoEquivs` property from `AbstractHafasLegacyProvider`.
