### PR TITLE
Enable build on Gradle 8.0, fix issues with json library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,11 @@ plugins {
 }
 
 group = 'de.schildbach.pte'
-archivesBaseName = 'public-transport-enabler'
 version = 'SNAPSHOT'
+
+base {
+    archivesName = 'public-transport-enabler'
+}
 
 repositories {
     mavenCentral()
@@ -16,7 +19,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
     implementation 'org.slf4j:slf4j-api:2.0.18'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
-    implementation 'org.json:json:20090211' // provided by Android
+    implementation 'org.json:json:20231013' // provided by Android
     implementation 'net.sf.kxml:kxml2:2.3.0' // provided by Android
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.slf4j:slf4j-jdk14:2.0.18'


### PR DESCRIPTION
- Update build.gradle to enable build on later versions of Gradle
- Avoid old json library version with known CVEs:

Dependency maven:org.json:json:20090211 is vulnerable

Update to unaffected version 20231013

WS-2017-3805,  Score: 7.5

Affected versions of JSON In Java are vulnerable to Denial of Service (DoS) when trying to initialize a JSONArray object and the input is [. This will cause the jvm to crash with StackOverflowError due to non-cyclical stack overflow.

Read More: https://www.mend.io/vulnerability-database/WS-2017-3805?utm_source=JetBrains

CVE-2022-45688,  Score: 7.5

A stack overflow in the XML.toJSONObject component of hutool-json v5.8.10 allows attackers to cause a Denial of Service (DoS) via crafted JSON or XML data.

Read More: https://www.mend.io/vulnerability-database/CVE-2022-45688?utm_source=JetBrains

CVE-2023-5072,  Score: 7.5

Denial of Service  in JSON-Java versions up to and including 20230618.  A bug in the parser means that an input string of modest size can lead to indefinite amounts of memory being used.

Read More: https://www.mend.io/vulnerability-database/CVE-2023-5072?utm_source=JetBrains

Results powered by Mend.io